### PR TITLE
CSI statefulset no longer needs hostNetworking and dummy Service

### DIFF
--- a/pkg/linode-bs/deploy/kubernetes/06-ss-csi-linode-controller.yaml
+++ b/pkg/linode-bs/deploy/kubernetes/06-ss-csi-linode-controller.yaml
@@ -1,20 +1,3 @@
-# stateful sets needs a headless service to provide pod network indentity
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-linode-controller
-  namespace: kube-system
-  labels:
-    app: csi-linode-controller
-spec:
-  selector:
-    app: csi-linode-controller
-  ports:
-    - name: dummy
-      port: 12345
-
----
-
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -33,7 +16,6 @@ spec:
         role: csi-linode
     spec:
       serviceAccount: csi-controller-sa
-      hostNetwork: true
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.0.0

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.1.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.1.yaml
@@ -286,23 +286,6 @@ metadata:
 provisioner: linodebs.csi.linode.com
 ---
 # pkg/linode-bs/deploy/kubernetes/06-ss-csi-linode-controller.yaml
-# stateful sets needs a headless service to provide pod network indentity
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-linode-controller
-  namespace: kube-system
-  labels:
-    app: csi-linode-controller
-spec:
-  selector:
-    app: csi-linode-controller
-  ports:
-    - name: dummy
-      port: 12345
-
----
-
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -321,7 +304,6 @@ spec:
         role: csi-linode
     spec:
       serviceAccount: csi-controller-sa
-      hostNetwork: true
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.0.0


### PR DESCRIPTION
removes `hostnetworking:true` and the dummy service port for the stateful set from the `csi-linode-controller`.

This change is already present in the canary image. (uncommitted .. CI/CD fail)