### PR TITLE
Upgrade DaemonSet apiVersion to apps/v1

### DIFF
--- a/pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
+++ b/pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.1.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.1.yaml
@@ -362,7 +362,7 @@ spec:
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.2.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.2.yaml
@@ -369,7 +369,7 @@ spec:
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.3.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.0.3.yaml
@@ -369,7 +369,7 @@ spec:
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.0.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.0.yaml
@@ -376,7 +376,7 @@ spec:
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.2.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.2.yaml
@@ -376,7 +376,7 @@ spec:
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.3.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.3.yaml
@@ -376,7 +376,7 @@ spec:
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml
@@ -376,7 +376,7 @@ spec:
 ---
 # pkg/linode-bs/deploy/kubernetes/07-ds-csi-linode-node.yaml
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-linode-node
   namespace: kube-system


### PR DESCRIPTION
### General:
DaemonSets have been promoted to apps/v1 and the current manifest is incompatible with recent versions of Kubernetes

* [x ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x ] Are you addressing a single feature in this PR? 
1. [x ] Are your commits atomic, addressing one change per commit?
1. [x ] Are you following the conventions of the language? 
1. [x ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

