### PR TITLE
Bump CSI image tag to v0.1.5 in the deployment manifest

### DIFF
--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.5.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.1.5.yaml
@@ -339,7 +339,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: linode-csi-plugin
-          image: linode/linode-blockstorage-csi-driver:v0.1.4
+          image: linode/linode-blockstorage-csi-driver:v0.1.5
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--token=$(LINODE_TOKEN)"
@@ -440,7 +440,7 @@ spec:
             - name: registration-dir
               mountPath: /registration/
         - name: csi-linode-plugin
-          image: linode/linode-blockstorage-csi-driver:v0.1.4
+          image: linode/linode-blockstorage-csi-driver:v0.1.5
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--token=$(LINODE_TOKEN)"


### PR DESCRIPTION
Bump CSI image tag to v0.1.5 in the deployment manifest

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?
