### PR TITLE
Use commit hashes for action references

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,19 +1,19 @@
 name: Publish Docker Release
 on:
   release:
-    types: [published]
+    types: [ published ]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Build
-      run: make build-linux
-    - name: Publish latest to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: linode/linode-blockstorage-csi-driver
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ github.event.release.tag_name }}"
-        dockerfile: "./app/linode/Dockerfile"
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # pin@master
+      - name: Build
+        run: make build-linux
+      - name: Publish latest to Registry
+        uses: elgohr/Publish-Docker-Github-Action@13c6c46d98bc92e6c046454248cd28630400846a # pin@master
+        with:
+          name: linode/linode-blockstorage-csi-driver
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest,${{ github.event.release.tag_name }}"
+          dockerfile: "./app/linode/Dockerfile"

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -1,21 +1,21 @@
 name: Release manifests
 on:
   release:
-    types: [published]
+    types: [ published ]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Build manifest
-      run: "./hack/release-yaml.sh ${{ github.event.release.tag_name }}"
-    - name: Commit files
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add -- pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver*\.yaml
-        git commit -m "Update manifests"
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # pin@master
+      - name: Build manifest
+        run: "./hack/release-yaml.sh ${{ github.event.release.tag_name }}"
+      - name: Commit files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -- pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver*\.yaml
+          git commit -m "Update manifests"
+      - name: Push changes
+        uses: ad-m/github-push-action@65392840bda2e774394d5cd38ca33e5918aec2d3 # pin@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: micnncim/action-label-syncer@v1
+      - uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # pin@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,9 +9,8 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4 # pin@v5
         with:
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
- Alters all workflows to reference actions by their commit SHA rather than their version/tag
- Addresses security concerns described in [GitHub's documentation](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions)