### PR TITLE
Move CSIDriver API from v1beta to v1

### DIFF
--- a/app/linode/Dockerfile
+++ b/app/linode/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.vendorVersion='${REV}' -extldflags "-static"' -o /bin/linode-blockstorage-csi-driver /linode
 
-FROM alpine
+FROM alpine:3.16.2
 LABEL maintainers="Linode"
 LABEL description="Linode CSI Driver"
 

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.5.1.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.5.1.yaml
@@ -364,7 +364,7 @@ spec:
             secretKeyRef:
               key: token
               name: linode
-        image: linode/linode-blockstorage-csi-driver:v0.5.0
+        image: linode/linode-blockstorage-csi-driver:v0.5.1
         name: linode-csi-plugin
         volumeMounts:
         - mountPath: /linode-info
@@ -465,7 +465,7 @@ spec:
             secretKeyRef:
               key: token
               name: linode
-        image: linode/linode-blockstorage-csi-driver:v0.5.0
+        image: linode/linode-blockstorage-csi-driver:v0.5.1
         imagePullPolicy: Always
         name: csi-linode-plugin
         securityContext:

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.5.1.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.5.1.yaml
@@ -1,0 +1,563 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: linode-block-storage
+  namespace: kube-system
+provisioner: linodebs.csi.linode.com
+---
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: linode-block-storage-retain
+  namespace: kube-system
+provisioner: linodebs.csi.linode.com
+reclaimPolicy: Retain
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-sa
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linode-csi-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-attacher-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-resizer-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linode-csi-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linode-csi-role
+subjects:
+- kind: ServiceAccount
+  name: csi-node-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-controller-attacher-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-attacher-role
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-controller-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-controller-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-resizer-role
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  get-linode-id.sh: |-
+    #!/bin/bash -efu
+    id="$(kubectl get node/"${NODE_NAME}" -o jsonpath='{.spec.providerID}')"
+    if [[ ! -z "${id}" ]]; then
+      echo "${id}"
+      echo -n "${id:9}" > /linode-info/linode-id
+      exit 0
+    fi
+    echo "Provider ID not found"
+    # Exit here so that we wait for the CCM to initialize the provider ID
+    exit 1
+kind: ConfigMap
+metadata:
+  labels:
+    app: csi-linode
+  name: get-linode-id
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: csi-linode-controller
+  name: csi-linode-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-linode-controller
+  serviceName: csi-linode
+  template:
+    metadata:
+      labels:
+        app: csi-linode-controller
+        role: csi-linode
+    spec:
+      containers:
+      - args:
+        - --default-fstype=ext4
+        - --volume-name-prefix=pvc
+        - --volume-name-uuid-length=16
+        - --csi-address=$(ADDRESS)
+        - --v=2
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --v=2
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --v=2
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+        imagePullPolicy: IfNotPresent
+        name: csi-resizer
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --token=$(LINODE_TOKEN)
+        - --url=$(LINODE_API_URL)
+        - --node=$(NODE_NAME)
+        - --bs-prefix=$(LINODE_BS_PREFIX)
+        - --v=2
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: LINODE_API_URL
+          value: https://api.linode.com/v4
+        - name: LINODE_BS_PREFIX
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: LINODE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: linode
+        image: linode/linode-blockstorage-csi-driver:v0.5.0
+        name: linode-csi-plugin
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      initContainers:
+      - command:
+        - /scripts/get-linode-id.sh
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: bitnami/kubectl:1.16.3-debian-10-r36
+        name: init
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+      serviceAccount: csi-controller-sa
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - emptyDir: {}
+        name: linode-info
+      - configMap:
+          defaultMode: 493
+          name: get-linode-id
+        name: get-linode-id
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: csi-linode-node
+  name: csi-linode-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-linode-node
+  template:
+    metadata:
+      labels:
+        app: csi-linode-node
+        role: csi-linode
+    spec:
+      containers:
+      - args:
+        - --v=2
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/linodebs.csi.linode.com/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
+        name: csi-node-driver-registrar
+        volumeMounts:
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --token=$(LINODE_TOKEN)
+        - --url=$(LINODE_API_URL)
+        - --node=$(NODE_NAME)
+        - --v=2
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: LINODE_API_URL
+          value: https://api.linode.com/v4
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LINODE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: linode
+        image: linode/linode-blockstorage-csi-driver:v0.5.0
+        imagePullPolicy: Always
+        name: csi-linode-plugin
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+          name: pods-mount-dir
+        - mountPath: /dev
+          name: device-dir
+      hostNetwork: true
+      initContainers:
+      - command:
+        - /scripts/get-linode-id.sh
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: bitnami/kubectl:1.16.3-debian-10-r36
+        name: init
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+      priorityClassName: system-node-critical
+      serviceAccount: csi-node-sa
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: linode-info
+      - configMap:
+          defaultMode: 493
+          name: get-linode-id
+        name: get-linode-id
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: DirectoryOrCreate
+        name: registration-dir
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/linodebs.csi.linode.com
+          type: DirectoryOrCreate
+        name: plugin-dir
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: pods-mount-dir
+      - hostPath:
+          path: /dev
+        name: device-dir
+      - hostPath:
+          path: /etc/udev
+          type: Directory
+        name: udev-rules-etc
+      - hostPath:
+          path: /lib/udev
+          type: Directory
+        name: udev-rules-lib
+      - hostPath:
+          path: /run/udev
+          type: Directory
+        name: udev-socket
+      - hostPath:
+          path: /sys
+          type: Directory
+        name: sys
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: linodebs.csi.linode.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true

--- a/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml
+++ b/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml
@@ -364,7 +364,7 @@ spec:
             secretKeyRef:
               key: token
               name: linode
-        image: linode/linode-blockstorage-csi-driver:v0.5.0
+        image: linode/linode-blockstorage-csi-driver:v0.5.1
         name: linode-csi-plugin
         volumeMounts:
         - mountPath: /linode-info
@@ -465,7 +465,7 @@ spec:
             secretKeyRef:
               key: token
               name: linode
-        image: linode/linode-blockstorage-csi-driver:v0.5.0
+        image: linode/linode-blockstorage-csi-driver:v0.5.1
         imagePullPolicy: Always
         name: csi-linode-plugin
         securityContext:


### PR DESCRIPTION
Fixes #78
 
CSIDriver resource is built-in to the Kubernetes API as of kubernetes 1.14. As of kubernetes 1.18 it is GA. And as of kubernetes 1.22 the storage.k8s.io/v1beta1 API version is no longer available.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#storage-resources-v122


