### PR TITLE
Adding Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@ More information about the Kubernetes CSI can be found in the GitHub [Kubernetes
 
 ## Deployment
 
+There are two ways of deploying CSI. The recommended way is to use Helm and second way is to use manually set secrets on the kubernetes cluster then use kubectl to deploy using the given [`yaml` file](https://raw.githubusercontent.com/linode/linode-blockstorage-csi-driver/master/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml). 
+
 ### Requirements
 
 * Kubernetes v1.16+
 * The node `hostname` must match the Linode Instance `label`
+* [LINODE_API_TOKEN](https://cloud.linode.com/profile/tokens) (See 'Secure a Linode API Access Token' below).
+* Linode [REGION](https://api.linode.com/v4/regions).
 
 ### Secure a Linode API Access Token:
 
@@ -22,7 +26,54 @@ This token will need:
 * Read/Write access to Linodes (to attach and detach volumes)
 * A sufficient "Expiry" to allow for continued use of your volumes
 
-### Create a Kubernetes secret
+### [Recommended] Using Helm to deploy the CSI Driver
+
+Use the helm chart located under './helm-chart/csi-driver'. This dir has the manifest for Linode Block Storage CSI Driver.
+
+#### To deploy the CSI Driver run the following:
+```sh
+git clone git@github.com:linode/linode-blockstorage-csi-driver.git
+
+cd linode-blockstorage-csi-driver
+
+helm install linode-csi-driver ./helm-chart/csi-driver --set apiToken=$LINODE_API_TOKEN,region=$REGION
+```
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+#### Uninstall
+
+To uninstall linode-csi-driver from kubernetes cluster, run the following command:
+
+```sh
+
+helm uninstall linode-csi-driver
+
+```
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+#### Upgrade
+
+To upgrade when new changes are made to the helm chart, run the following command:
+
+```sh
+
+helm upgrade linode-csi-driver ./helm-chart/csi-driver --install --set apiToken=$LINODE_API_TOKEN,region=$REGION
+
+```
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+#### Configurations
+
+There are other variables that can be set to a different value. For list of all the modifiable variables/values, take a look at './helm-chart/csi-driver/values.yaml'. 
+
+Values can be set/overrided by using the '--set var=value,...' flag or by passing in a custom-values.yaml using '-f custom-values.yaml'.
+
+Recommendation: Use custom-values.yaml to override the variables to avoid any errors with template rendering
+
+
+### Using Kubectl to deploy CSI
+
+#### Create a kubernetes secret:
 
 Run the following commands to stash a `LINODE_TOKEN` in your Kubernetes cluster:
 
@@ -54,7 +105,7 @@ NAME                  TYPE                                  DATA      AGE
 linode          Opaque                                2         18h
 ```
 
-### Deploy the CSI
+#### Deploying CSI through kubectl:
 
 The following command will deploy the CSI driver with the related Kubernetes volume attachment, driver registration, and provisioning sidecars:
 

--- a/helm-chart/csi-driver/.helmignore
+++ b/helm-chart/csi-driver/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart/csi-driver/Chart.yaml
+++ b/helm-chart/csi-driver/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: linode-blockstorage-csi-driver
+description: The Container Storage Interface (CSI) Driver for Linode Block Storage enables container orchestrators such as Kubernetes to manage the life-cycle of persistant storage claims.
+type: application
+version: 1.0.0
+appVersion: "0.5.0"

--- a/helm-chart/csi-driver/templates/_helpers.tpl
+++ b/helm-chart/csi-driver/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "csi-driver.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "csi-driver.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "csi-driver.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "csi-driver.labels" -}}
+helm.sh/chart: {{ include "csi-driver.chart" . }}
+{{ include "csi-driver.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "csi-driver.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "csi-driver.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "csi-driver.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "csi-driver.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-chart/csi-driver/templates/csi-controller-attacher-binding-rbac.yaml
+++ b/helm-chart/csi-driver/templates/csi-controller-attacher-binding-rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-controller-attacher-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-attacher-role
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm-chart/csi-driver/templates/csi-controller-provisioner-binding-rbac.yaml
+++ b/helm-chart/csi-driver/templates/csi-controller-provisioner-binding-rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-controller-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm-chart/csi-driver/templates/csi-controller-resizer-binding-rbac.yaml
+++ b/helm-chart/csi-driver/templates/csi-controller-resizer-binding-rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-controller-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-resizer-role
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm-chart/csi-driver/templates/csi-controller-serviceaccount.yaml
+++ b/helm-chart/csi-driver/templates/csi-controller-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-sa
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: csi-linode-controller
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+  labels:
+    app: csi-linode-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-linode-controller
+  serviceName: csi-linode
+  template:
+    metadata:
+      labels:
+        app: csi-linode-controller
+        role: csi-linode
+    spec:
+      containers:
+      - args:
+        - --default-fstype=ext4
+        - --volume-name-prefix=pvc
+        - --volume-name-uuid-length=16
+        - --csi-address=$(ADDRESS)
+        - --v=2
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: {{ .Values.csiProvisioner.image }}:{{ .Values.csiProvisioner.tag }}
+        imagePullPolicy: {{ .Values.csiProvisioner.pullPolicy }}
+        name: csi-provisioner
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --v=2
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: {{ .Values.csiAttacher.image }}:{{ .Values.csiAttacher.tag }}
+        imagePullPolicy: {{ .Values.csiAttacher.pullPolicy }}
+        name: csi-attacher
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --v=2
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: {{ .Values.csiResizer.image }}:{{ .Values.csiResizer.tag }}
+        imagePullPolicy: {{ .Values.csiResizer.pullPolicy }}
+        name: csi-resizer
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --token=$(LINODE_TOKEN)
+        - --url=$(LINODE_API_URL)
+        - --node=$(NODE_NAME)
+        - --bs-prefix=$(LINODE_BS_PREFIX)
+        - --v=2
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: LINODE_API_URL
+          value: https://api.linode.com/v4
+        - name: LINODE_BS_PREFIX
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: LINODE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: linode
+        image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
+        name: linode-csi-plugin
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      initContainers:
+      - command:
+        - /scripts/get-linode-id.sh
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: {{ .Values.kubectl.image }}:{{ .Values.kubectl.tag }}
+        name: init
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+      serviceAccount: csi-controller-sa
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - emptyDir: {}
+        name: linode-info
+      - configMap:
+          defaultMode: 493
+          name: get-linode-id
+        name: get-linode-id

--- a/helm-chart/csi-driver/templates/csi-node-serviceaccount.yaml
+++ b/helm-chart/csi-driver/templates/csi-node-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node-sa
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm-chart/csi-driver/templates/csi-secrets.yaml
+++ b/helm-chart/csi-driver/templates/csi-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linode
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+stringData:
+  token: {{ required ".Values.apiToken required" .Values.apiToken }}
+  region: {{ required ".Values.region required" .Values.region }}
+type: Opaque

--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-linode-node
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+  labels:
+    app: csi-linode-node
+spec:
+  selector:
+    matchLabels:
+      app: csi-linode-node
+  template:
+    metadata:
+      labels:
+        app: csi-linode-node
+        role: csi-linode
+    spec:
+      containers:
+      - args:
+        - --v=2
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/linodebs.csi.linode.com/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: {{ .Values.csiNodeDriverRegistrar.image}}:{{ .Values.csiNodeDriverRegistrar.tag}}
+        name: csi-node-driver-registrar
+        volumeMounts:
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --token=$(LINODE_TOKEN)
+        - --url=$(LINODE_API_URL)
+        - --node=$(NODE_NAME)
+        - --v=2
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: LINODE_API_URL
+          value: https://api.linode.com/v4
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LINODE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: linode
+        image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.csiLinodePlugin.pullPolicy }}
+        name: csi-linode-plugin
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+          name: pods-mount-dir
+        - mountPath: /dev
+          name: device-dir
+      hostNetwork: true
+      initContainers:
+      - command:
+        - /scripts/get-linode-id.sh
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: {{ .Values.kubectl.image }}:{{ .Values.kubectl.tag }}
+        name: init
+        volumeMounts:
+        - mountPath: /linode-info
+          name: linode-info
+        - mountPath: /scripts
+          name: get-linode-id
+      priorityClassName: system-node-critical
+      serviceAccount: csi-node-sa
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: linode-info
+      - configMap:
+          defaultMode: 493
+          name: get-linode-id
+        name: get-linode-id
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: DirectoryOrCreate
+        name: registration-dir
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/linodebs.csi.linode.com
+          type: DirectoryOrCreate
+        name: plugin-dir
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: pods-mount-dir
+      - hostPath:
+          path: /dev
+        name: device-dir
+      - hostPath:
+          path: /etc/udev
+          type: Directory
+        name: udev-rules-etc
+      - hostPath:
+          path: /lib/udev
+          type: Directory
+        name: udev-rules-lib
+      - hostPath:
+          path: /run/udev
+          type: Directory
+        name: udev-socket
+      - hostPath:
+          path: /sys
+          type: Directory
+        name: sys

--- a/helm-chart/csi-driver/templates/external-attacher-rbac.yaml
+++ b/helm-chart/csi-driver/templates/external-attacher-rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-attacher-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/helm-chart/csi-driver/templates/external-provisioner-rbac.yaml
+++ b/helm-chart/csi-driver/templates/external-provisioner-rbac.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/helm-chart/csi-driver/templates/external-resizer-rbac.yaml
+++ b/helm-chart/csi-driver/templates/external-resizer-rbac.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-resizer-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/helm-chart/csi-driver/templates/get-linode-id.yaml
+++ b/helm-chart/csi-driver/templates/get-linode-id.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: get-linode-id
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+  labels:
+    app: csi-linode
+data:
+  get-linode-id.sh: |-
+    #!/bin/bash -efu
+    id="$(kubectl get node/"${NODE_NAME}" -o jsonpath='{.spec.providerID}')"
+    if [[ ! -z "${id}" ]]; then
+      echo "${id}"
+      echo -n "${id:9}" > /linode-info/linode-id
+      exit 0
+    fi
+    echo "Provider ID not found"
+    # Exit here so that we wait for the CCM to initialize the provider ID
+    exit 1

--- a/helm-chart/csi-driver/templates/linode-block-storage-retain.yaml
+++ b/helm-chart/csi-driver/templates/linode-block-storage-retain.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: linode-block-storage-retain
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+allowVolumeExpansion: true
+provisioner: linodebs.csi.linode.com
+reclaimPolicy: Retain

--- a/helm-chart/csi-driver/templates/linode-block-storage.yaml
+++ b/helm-chart/csi-driver/templates/linode-block-storage.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: linode-block-storage
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+allowVolumeExpansion: true
+provisioner: linodebs.csi.linode.com

--- a/helm-chart/csi-driver/templates/linode-csi-binding-rbac.yaml
+++ b/helm-chart/csi-driver/templates/linode-csi-binding-rbac.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linode-csi-binding
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linode-csi-role
+subjects:
+- kind: ServiceAccount
+  name: csi-node-sa
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm-chart/csi-driver/templates/linode-csi-rbac.yaml
+++ b/helm-chart/csi-driver/templates/linode-csi-rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linode-csi-role
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/helm-chart/csi-driver/templates/linodebs.csi.linode.com.yaml
+++ b/helm-chart/csi-driver/templates/linodebs.csi.linode.com.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: linodebs.csi.linode.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -1,0 +1,38 @@
+# Secrets:
+# apiToken [Required] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens) 
+apiToken: ""
+
+# region [Required] - Must be a Linode region. (https://api.linode.com/v4/regions)
+region: ""
+
+# Default namespace is "kube-system" but it can be set to another namespace
+namespace: kube-system
+
+# Images - Default 
+csiProvisioner:
+  image: registry.k8s.io/sig-storage/csi-provisioner
+  tag: v3.0.0
+  pullPolicy: IfNotPresent
+
+csiAttacher:
+  image: registry.k8s.io/sig-storage/csi-attacher
+  tag: v3.3.0
+  pullPolicy: IfNotPresent
+
+csiResizer:
+  image: registry.k8s.io/sig-storage/csi-resizer
+  tag: v1.3.0
+  pullPolicy: IfNotPresent
+
+csiLinodePlugin:
+  image: linode/linode-blockstorage-csi-driver 
+  tag: v0.5.0
+  pullPolicy: IfNotPresent
+
+kubectl:
+  image: bitnami/kubectl
+  tag: 1.25.6-debian-11-r7
+
+csiNodeDriverRegistrar:
+  image: registry.k8s.io/sig-storage/csi-node-driver-registrar
+  tag: v1.3.0


### PR DESCRIPTION
### Reasoning:

Adding a helm chart for this component to bring the CSI driver in line with the industry standard of using helm charts to deploy on Kubernetes. This will simplify the deployment process for users. Helm charts are also easier to maintain and understand for developers.

This chart was created using the concatenated yaml file found here: https://raw.githubusercontent.com/linode/linode-blockstorage-csi-driver/master/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)
