### PR TITLE
fix linode-id in other places

### DIFF
--- a/deploy/kubernetes/base/cm-get-linode-id.yaml
+++ b/deploy/kubernetes/base/cm-get-linode-id.yaml
@@ -20,3 +20,5 @@ data:
       exit 0
     fi
     echo "Provider ID not found"
+    # Exit here so that we wait for the CCM to initialize the provider ID
+    exit 1

--- a/deploy/kubernetes/base/cm-get-linode-id.yaml
+++ b/deploy/kubernetes/base/cm-get-linode-id.yaml
@@ -11,9 +11,12 @@ data:
     id="$(kubectl get node/"${NODE_NAME}" -o jsonpath='{.spec.providerID}')"
     if [[ ! -z "${id}" ]]; then
       echo "${id}"
-      echo -n "${id:9}" > /linode-info/linode-id
+      if [[  "${id}" =~ "linode://" ]]; then
+        echo -n "${id:9}" > /linode-info/linode-id
+      else
+        echo "Provider ID: ${id} does not have linode:// prefix."
+        echo "Not populating /linode-info/linode-id file"
+      fi
       exit 0
     fi
     echo "Provider ID not found"
-    # Exit here so that we wait for the CCM to initialize the provider ID
-    exit 1

--- a/helm-chart/csi-driver/templates/get-linode-id.yaml
+++ b/helm-chart/csi-driver/templates/get-linode-id.yaml
@@ -20,3 +20,5 @@ data:
       exit 0
     fi
     echo "Provider ID not found"
+    # Exit here so that we wait for the CCM to initialize the provider ID
+    exit 1

--- a/helm-chart/csi-driver/templates/get-linode-id.yaml
+++ b/helm-chart/csi-driver/templates/get-linode-id.yaml
@@ -11,9 +11,12 @@ data:
     id="$(kubectl get node/"${NODE_NAME}" -o jsonpath='{.spec.providerID}')"
     if [[ ! -z "${id}" ]]; then
       echo "${id}"
-      echo -n "${id:9}" > /linode-info/linode-id
+      if [[  "${id}" =~ "linode://" ]]; then
+        echo -n "${id:9}" > /linode-info/linode-id
+      else
+        echo "Provider ID: ${id} does not have linode:// prefix."
+        echo "Not populating /linode-info/linode-id file"
+      fi
       exit 0
     fi
     echo "Provider ID not found"
-    # Exit here so that we wait for the CCM to initialize the provider ID
-    exit 1


### PR DESCRIPTION
Applies the fix from #92 to the helm chart and config map where `get-linode-id` is defined.


### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

