### PR TITLE
Embed REV in Docker image

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -6,12 +6,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # pin@master
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3.5.0
+        with:
+          fetch-depth: 0
+      - name: Save revision
+        run: echo "REV=$(git describe --long --tags --dirty)" >> $GITHUB_ENV
       - name: Build and Publish latest release to Registry
-        uses: elgohr/Publish-Docker-Github-Action@13c6c46d98bc92e6c046454248cd28630400846a # pin@master
+        uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b # pin@v5
         with:
           name: linode/linode-blockstorage-csi-driver
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest,${{ github.event.release.tag_name }}"
           dockerfile: "./app/linode/Dockerfile"
+          buildargs: REV


### PR DESCRIPTION
### Rationale

`git describe` output wasn't being stamped into the binary, but we need it at startup time, so the latest version failed to start.

- I originally wanted to just set `REV: ${{ github.sha }}` and call it a day, but then the stamped version would differ from what we use today (`tag-commits_since-hash`), so I replicated the whole `git describe` call in the action itself to stay consistent.
- I bumped both dependent actions as they were getting a bit old (and used deprecated calls that will be removed from GHA in June)
- Had to increase `fetch-depth` as by default `actions/checkout` only downloads the last commit, but we need the whole history to run our `git describe`
- I considered changing the action to use an official one from Docker, but decided against it to keep the PR minimal. We might reconsider it in the future.
- I tested it against my personal Dockerhub repo and saw it being fixed:

```
$ docker run --rm -it okokes/linode-blockstorage-csi-driver:latest -v 5
I0331 08:41:55.057483       1 main.go:59] Driver vendor version v0.5.1-19-g30bc663
F0331 08:41:55.711539       1 main.go:72] Failed to set up metadata service: [401] Invalid Token
```

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

