### PR TITLE
allow the default storage class to be overridden for the helm chart

### DIFF
--- a/helm-chart/csi-driver/templates/linode-block-storage-retain.yaml
+++ b/helm-chart/csi-driver/templates/linode-block-storage-retain.yaml
@@ -3,8 +3,10 @@ kind: StorageClass
 metadata:
   name: linode-block-storage-retain
   namespace: {{ required ".Values.namespace required" .Values.namespace }}
+{{- if eq .Values.defaultStorageClass "linode-block-storage-retain" }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
 allowVolumeExpansion: true
 provisioner: linodebs.csi.linode.com
 reclaimPolicy: Retain

--- a/helm-chart/csi-driver/templates/linode-block-storage.yaml
+++ b/helm-chart/csi-driver/templates/linode-block-storage.yaml
@@ -3,5 +3,9 @@ kind: StorageClass
 metadata:
   name: linode-block-storage
   namespace: {{ required ".Values.namespace required" .Values.namespace }}
+{{- if eq .Values.defaultStorageClass "linode-block-storage" }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
 allowVolumeExpansion: true
 provisioner: linodebs.csi.linode.com

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -8,6 +8,10 @@ region: ""
 # Default namespace is "kube-system" but it can be set to another namespace
 namespace: kube-system
 
+# Default storageClass is "linode-block-storage-retain" but it can be set to
+# "linode-block-storage" or left as an empty string
+defaultStorageClass: linode-block-storage-retain
+
 # Images - Default 
 csiProvisioner:
   image: registry.k8s.io/sig-storage/csi-provisioner


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

### Why
There are applicable cases where users may not want to have volumes be retained by default (e.g. testing clusters that have workloads with PVCTemplates that don't define a `storageClassName` in the spec). This change does not change the default storage class but instead allows the user to choose which of the two if either should be the default.