### PR TITLE
initial RPC_GET_VOLUME_STAT support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/kubernetes-csi/csi-test/v3 v3.1.1
 	github.com/linode/linodego v0.21.0
 	golang.org/x/net v0.7.0
+	golang.org/x/sys v0.5.0
 	google.golang.org/grpc v1.31.1
 	k8s.io/apimachinery v0.19.2
 	k8s.io/utils v0.0.0-20201005171033-6301aaf42dc7
@@ -20,7 +21,6 @@ require (
 	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/onsi/gomega v1.7.1 // indirect
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
-	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect

--- a/pkg/linode-bs/driver.go
+++ b/pkg/linode-bs/driver.go
@@ -94,6 +94,7 @@ func (linodeDriver *LinodeDriver) SetupLinodeDriver(linodeClient linodeclient.Li
 	ns := []csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 	}
 	if err := linodeDriver.AddNodeServiceCapabilities(ns); err != nil {
 		return err

--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/metadata"
 	mountmanager "github.com/linode/linode-blockstorage-csi-driver/pkg/mount-manager"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/utils/mount"
@@ -304,5 +305,27 @@ func (ns *LinodeNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInf
 }
 
 func (ns *LinodeNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "NodeGetVolumeStats is not yet implemented")
+	var statfs unix.Statfs_t
+	// See http://man7.org/linux/man-pages/man2/statfs.2.html for details.
+	err := unix.Statfs(req.VolumePath, &statfs)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get stats: %v", err.Error())
+	}
+
+	return &csi.NodeGetVolumeStatsResponse{
+		Usage: []*csi.VolumeUsage{
+			{
+				Available: int64(statfs.Bavail) * int64(statfs.Bsize),
+				Total:     int64(statfs.Blocks) * int64(statfs.Bsize),
+				Used:      (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize),
+				Unit:      csi.VolumeUsage_BYTES,
+			},
+			{
+				Available: int64(statfs.Ffree),
+				Total:     int64(statfs.Files),
+				Used:      int64(statfs.Files) - int64(statfs.Ffree),
+				Unit:      csi.VolumeUsage_INODES,
+			},
+		},
+	}, nil
 }

--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -313,6 +314,9 @@ func (ns *LinodeNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.Nod
 	// See http://man7.org/linux/man-pages/man2/statfs.2.html for details.
 	err := unix.Statfs(req.VolumePath, &statfs)
 	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, status.Errorf(codes.NotFound, "volume path not found: %v", err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "failed to get stats: %v", err.Error())
 	}
 

--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -305,6 +305,10 @@ func (ns *LinodeNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInf
 }
 
 func (ns *LinodeNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	if req.VolumeId == "" || req.VolumePath == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume ID or path empty")
+	}
+
 	var statfs unix.Statfs_t
 	// See http://man7.org/linux/man-pages/man2/statfs.2.html for details.
 	err := unix.Statfs(req.VolumePath, &statfs)


### PR DESCRIPTION
closes #62

Implement CSI RPC to support GET_VOLUME_STATS, which allows the kubelet to monitor PVC usage, which is most often used with prometheus and/or kube-prometheus-stack, and can be used to alert when a PVC is close to being full

based off of https://github.com/digitalocean/csi-digitalocean/pull/197

haven't added tests yet, but I built `ghcr.io/beryju/linode-blockstorage-csi-driver:v0.5.2-0-ge8e0af0-dirty` and am testing that in my LKE cluster, which seems to work fine

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

