### PR TITLE
Allow passing the linodeApiToken and region via secret references

### DIFF
--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -78,8 +78,8 @@ spec:
         - name: LINODE_TOKEN
           valueFrom:
             secretKeyRef:
-              key: token
-              name: linode
+              name: {{ if .Values.secretRef }}{{ .Values.secretRef.name | default "linode" }}{{ else }}"linode"{{ end }}
+              key: {{ if .Values.secretRef }}{{ .Values.secretRef.apiTokenRef | default "token" }}{{ else }}"token"{{ end }}
         image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
         name: linode-csi-plugin
         volumeMounts:

--- a/helm-chart/csi-driver/templates/csi-secrets.yaml
+++ b/helm-chart/csi-driver/templates/csi-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secretRef }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,5 @@ stringData:
   token: {{ required ".Values.apiToken required" .Values.apiToken }}
   region: {{ required ".Values.region required" .Values.region }}
 type: Opaque
+{{- end }}
+

--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -54,8 +54,8 @@ spec:
         - name: LINODE_TOKEN
           valueFrom:
             secretKeyRef:
-              key: token
-              name: linode
+              name: {{ if .Values.secretRef }}{{ .Values.secretRef.name | default "linode" }}{{ else }}"linode"{{ end }}
+              key: {{ if .Values.secretRef }}{{ .Values.secretRef.apiTokenRef | default "token" }}{{ else }}"token"{{ end }}
         image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.csiLinodePlugin.pullPolicy }}
         name: csi-linode-plugin

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -1,12 +1,18 @@
 # Secrets:
-# apiToken [Required] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens) 
+# apiToken [Required if secretRef is not set] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens)
 apiToken: ""
 
-# region [Required] - Must be a Linode region. (https://api.linode.com/v4/regions)
+# region [Required if secretRef is not set] - Must be a Linode region. (https://api.linode.com/v4/regions)
 region: ""
 
 # Default namespace is "kube-system" but it can be set to another namespace
 namespace: kube-system
+
+# Set these values if your APIToken and region are already present in a k8s secret.
+# secretRef:
+#   name: "linode"
+#   apiTokenRef: "apiToken"
+#   regionRef: "region"
 
 # Default storageClass is "linode-block-storage-retain" but it can be set to
 # "linode-block-storage" or left as an empty string


### PR DESCRIPTION
### General:
* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:
Adding support for passing the LinodeAPIToken and region via secret references instead of raw helm values. This prevents the disclosure of the token in values files when using gitops practices.

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

