### PR TITLE
Enhance get-linode-id.sh script to try getting ID from multiple sources

### DIFF
--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -89,6 +89,7 @@ spec:
           name: get-linode-id
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
+      hostNetwork: true
       initContainers:
       - command:
         - /scripts/get-linode-id.sh
@@ -99,8 +100,16 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
         image: {{ .Values.kubectl.image }}:{{ .Values.kubectl.tag }}
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
         name: init
         volumeMounts:
+        - mountPath: /dev
+          name: dev
         - mountPath: /linode-info
           name: linode-info
         - mountPath: /scripts
@@ -122,3 +131,7 @@ spec:
           defaultMode: 493
           name: get-linode-id
         name: get-linode-id
+      - hostPath:
+          path: /dev
+          type: Directory
+        name: dev

--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -87,8 +87,16 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         image: {{ .Values.kubectl.image }}:{{ .Values.kubectl.tag }}
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
         name: init
         volumeMounts:
+        - mountPath: /dev
+          name: device-dir
         - mountPath: /linode-info
           name: linode-info
         - mountPath: /scripts

--- a/helm-chart/csi-driver/templates/get-linode-id.yaml
+++ b/helm-chart/csi-driver/templates/get-linode-id.yaml
@@ -8,17 +8,57 @@ metadata:
 data:
   get-linode-id.sh: |-
     #!/bin/bash -efu
-    id="$(kubectl get node/"${NODE_NAME}" -o jsonpath='{.spec.providerID}')"
-    if [[ ! -z "${id}" ]]; then
-      echo "${id}"
-      if [[  "${id}" =~ "linode://" ]]; then
-        echo -n "${id:9}" > /linode-info/linode-id
-      else
-        echo "Provider ID: ${id} does not have linode:// prefix."
-        echo "Not populating /linode-info/linode-id file"
+    # Define Metadata API URL
+    META_IP="169.254.169.254"
+    META_API="http://$META_IP/v1"
+    ID=""
+
+    # Function to check if Metadata API is reachable
+    check_metadata_api() {
+       ping -c 1 $META_IP > /dev/null 2>&1
+       return $?
+    }
+
+    if check_metadata_api; then
+      # Try to get ID using Metadata API with a 5-second timeout
+      TOKEN=$(curl -sS -m 5 -X PUT -H "Metadata-Token-Expiry-Seconds: 3600" $META_API/token || true)
+      if [ ! -z "$TOKEN" ]; then
+        ID=$(curl -sS -m 5 -H "Metadata-Token: $TOKEN" $META_API/instance | grep -v "uuid" | awk -F': ' '/id:/{print $2}'  | tr -d '\n' || true)
+        echo "Metadata linode ID was $ID"
       fi
-      exit 0
     fi
-    echo "Provider ID not found"
-    # Exit here so that we wait for the CCM to initialize the provider ID
-    exit 1
+
+    # If Metadata API fails, try dmidecode
+    if [ -z "$ID" ]; then
+        echo "Getting Linode ID using dmidecode"
+        apk add --update dmidecode
+        ID=$(dmidecode -t 1 | awk -F': ' '/Serial Number/{print $2}' | tr -d '\n')
+        echo "Dmidecode linode ID was $ID"
+    fi
+
+    # If dmidecode fails, use kubectl method
+    if [ -z "$ID" ]; then
+      echo "Getting Linode ID using kubectl"
+      id="$(kubectl get node/"${NODE_NAME}" -o jsonpath='{.spec.providerID}')"
+      if [[ ! -z "${id}" ]]; then
+        echo "${id}"
+        if [[ "${id}" =~ "linode://" ]]; then
+          echo -n "${id:9}" > /linode-info/linode-id
+          echo "node-label linode ID was $id"
+        else
+          echo "Provider ID: ${id} does not have linode:// prefix."
+          echo "Not populating /linode-info/linode-id file"
+        fi
+        exit 0
+      fi
+    fi
+
+    # All has failed, still 0. Then exit the script, no point continuing on this broken cluster
+    if [ -z "$ID" ]; then
+      echo "Unable to fetch the linode-id"
+      exit 1
+    fi
+
+    # Save ID to file
+    echo -n $ID > /linode-info/linode-id
+    exit 0

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -40,8 +40,8 @@ csiLinodePlugin:
   pullPolicy: IfNotPresent
 
 kubectl:
-  image: bitnami/kubectl
-  tag: 1.25.6-debian-11-r7
+  image: alpine/k8s # This needs to be alpine based and have both kubectl and curl installed.
+  tag: 1.25.14
 
 csiNodeDriverRegistrar:
   image: registry.k8s.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
Modify get-linode-id.sh script to
1. Attempt to get the ID from metadata service
2. use dmidecode to fetch the id
3. fallback to fetching it from labels added by the linode-ccm

This fixes #115 

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

