### PR TITLE
adding windows build tags to hide unix.Statfs calls

### DIFF
--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -30,7 +29,6 @@ import (
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/metadata"
 	mountmanager "github.com/linode/linode-blockstorage-csi-driver/pkg/mount-manager"
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/utils/mount"
@@ -385,34 +383,5 @@ func (ns *LinodeNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInf
 }
 
 func (ns *LinodeNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	if req.VolumeId == "" || req.VolumePath == "" {
-		return nil, status.Error(codes.InvalidArgument, "volume ID or path empty")
-	}
-
-	var statfs unix.Statfs_t
-	// See http://man7.org/linux/man-pages/man2/statfs.2.html for details.
-	err := unix.Statfs(req.VolumePath, &statfs)
-	if err != nil {
-		if errors.Is(err, unix.ENOENT) {
-			return nil, status.Errorf(codes.NotFound, "volume path not found: %v", err.Error())
-		}
-		return nil, status.Errorf(codes.Internal, "failed to get stats: %v", err.Error())
-	}
-
-	return &csi.NodeGetVolumeStatsResponse{
-		Usage: []*csi.VolumeUsage{
-			{
-				Available: int64(statfs.Bavail) * int64(statfs.Bsize),
-				Total:     int64(statfs.Blocks) * int64(statfs.Bsize),
-				Used:      (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize),
-				Unit:      csi.VolumeUsage_BYTES,
-			},
-			{
-				Available: int64(statfs.Ffree),
-				Total:     int64(statfs.Files),
-				Used:      int64(statfs.Files) - int64(statfs.Ffree),
-				Unit:      csi.VolumeUsage_INODES,
-			},
-		},
-	}, nil
+	return nodeGetVolumeStats(ctx, req)
 }

--- a/pkg/linode-bs/nodeserver_all.go
+++ b/pkg/linode-bs/nodeserver_all.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package linodebs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func nodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	if req.VolumeId == "" || req.VolumePath == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume ID or path empty")
+	}
+
+	var statfs unix.Statfs_t
+	// See http://man7.org/linux/man-pages/man2/statfs.2.html for details.
+	err := unix.Statfs(req.VolumePath, &statfs)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, status.Errorf(codes.NotFound, "volume path not found: %v", err.Error())
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get stats: %v", err.Error())
+	}
+
+	return &csi.NodeGetVolumeStatsResponse{
+		Usage: []*csi.VolumeUsage{
+			{
+				Available: int64(statfs.Bavail) * int64(statfs.Bsize),
+				Total:     int64(statfs.Blocks) * int64(statfs.Bsize),
+				Used:      (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize),
+				Unit:      csi.VolumeUsage_BYTES,
+			},
+			{
+				Available: int64(statfs.Ffree),
+				Total:     int64(statfs.Files),
+				Used:      int64(statfs.Files) - int64(statfs.Ffree),
+				Unit:      csi.VolumeUsage_INODES,
+			},
+		},
+	}, nil
+}

--- a/pkg/linode-bs/nodeserver_windows.go
+++ b/pkg/linode-bs/nodeserver_windows.go
@@ -1,0 +1,14 @@
+package linodebs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func nodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, fmt.Sprintf("NodeGetVolumeStats is not yet implemented on Windows"))
+}


### PR DESCRIPTION
Getting `NodeGetVolumeStats` implemented added a dependency to `golang.org/x/sys/unix` which will never work on windows nodes. This driver does NOT support Windows nodes but this does make running the unit tests on a windows desktop work and as an open source project we should acknowledge development may happen on any platform.

## Running `TestDriverSuite` on a win11 desktop from Goland
**Before changes:** 
```
# github.com/linode/linode-blockstorage-csi-driver/pkg/linode-bs [github.com/linode/linode-blockstorage-csi-driver/pkg/linode-bs.test]
.\nodeserver.go:392:18: undefined: unix.Statfs_t
.\nodeserver.go:394:14: undefined: unix.Statfs
.\nodeserver.go:396:26: undefined: unix.ENOENT
```

**After changes:**  
```
=== RUN   TestDriverSuite
--- PASS: TestDriverSuite (0.00s)
PASS
```