### PR TITLE
Fixing E2E Tests

### DIFF
--- a/e2e/test/csi_driver_test.go
+++ b/e2e/test/csi_driver_test.go
@@ -182,14 +182,20 @@ var _ = Describe("Linode CSI Driver", func() {
 			JustBeforeEach(func() {
 				f = root.Invoke()
 				r := strconv.Itoa(rand.Intn(1024))
+				var err error
+
 				By("Creating the Persistent Volume Claim")
-				pvc = f.GetPersistentVolumeClaimObject("test-pvc-"+r, f.Namespace(), size, storageClass, volumeType)
+				pvc, err = f.GetPersistentVolumeClaimObject("test-pvc-"+r, f.Namespace(), size, storageClass, volumeType)
+				Expect(err).NotTo(HaveOccurred())
+
 				Eventually(func() error {
 					return f.CreatePersistentVolumeClaim(pvc)
 				}, f.Timeout, f.RetryInterval).Should(Succeed())
 
 				By("Creating Pod with PVC")
-				pod = framework.GetPodObject("test-pod"+r, f.Namespace(), pvc.Name, volumeType)
+				pod, err = f.GetPodObject("test-pod"+r, f.Namespace(), pvc.Name, volumeType)
+				Expect(err).NotTo(HaveOccurred())
+
 				Eventually(func() error {
 					return f.CreatePod(pod)
 				}, f.Timeout, f.RetryInterval).Should(Succeed())

--- a/e2e/test/framework/framework.go
+++ b/e2e/test/framework/framework.go
@@ -1,7 +1,10 @@
 package framework
 
 import (
+	"fmt"
 	"time"
+
+	core "k8s.io/api/core/v1"
 
 	"github.com/appscode/go/crypto/rand"
 	"github.com/linode/linodego"
@@ -15,6 +18,9 @@ var (
 	K8sVersion     = ""
 	Timeout        time.Duration
 	RetryInterval  time.Duration
+
+	VolumeTypeRequiredError = fmt.Errorf("volumeType is required and must be one of [%s, %s]",
+		core.PersistentVolumeFilesystem, core.PersistentVolumeBlock)
 )
 
 type Framework struct {

--- a/e2e/test/framework/pod.go
+++ b/e2e/test/framework/pod.go
@@ -6,6 +6,7 @@ import (
 	"github.com/appscode/go/wait"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kmodules.xyz/client-go/tools/exec"
 )
@@ -105,6 +106,16 @@ func (f *Invocation) WaitForReady(meta metav1.ObjectMeta) error {
 			return true, nil
 		}
 		return false, nil
+	})
+}
+
+func (f *Invocation) WaitForDelete(meta metav1.ObjectMeta) error {
+	return wait.PollImmediate(f.RetryInterval, f.Timeout, func() (bool, error) {
+		_, err := f.kubeClient.CoreV1().Pods(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
 	})
 }
 

--- a/e2e/test/framework/pvc.go
+++ b/e2e/test/framework/pvc.go
@@ -11,11 +11,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (f *Invocation) GetPersistentVolumeClaimObject(size, storageClass string, isblock bool) *core.PersistentVolumeClaim {
+func (f *Invocation) GetPersistentVolumeClaimObject(name, namespace, size, storageClass string, isBlock bool) *core.PersistentVolumeClaim {
 
 	var volType core.PersistentVolumeMode
 
-	if isblock {
+	if isBlock {
 		volType = core.PersistentVolumeBlock
 	} else {
 		volType = core.PersistentVolumeFilesystem

--- a/e2e/test/framework/pvc.go
+++ b/e2e/test/framework/pvc.go
@@ -5,22 +5,15 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/linode/linodego"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (f *Invocation) GetPersistentVolumeClaimObject(name, namespace, size, storageClass string, isBlock bool) *core.PersistentVolumeClaim {
-
-	var volType core.PersistentVolumeMode
-
-	if isBlock {
-		volType = core.PersistentVolumeBlock
-	} else {
-		volType = core.PersistentVolumeFilesystem
-	}
-
+func (f *Invocation) GetPersistentVolumeClaimObject(name, namespace, size, storageClass string, volumeType core.PersistentVolumeMode) *core.PersistentVolumeClaim {
 	return &core.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -30,11 +23,11 @@ func (f *Invocation) GetPersistentVolumeClaimObject(name, namespace, size, stora
 			AccessModes: []core.PersistentVolumeAccessMode{
 				core.ReadWriteOnce,
 			},
-			VolumeMode:       &volType,
+			VolumeMode:       &volumeType,
 			StorageClassName: &storageClass,
 			Resources: core.ResourceRequirements{
 				Requests: core.ResourceList{
-					core.ResourceName(core.ResourceStorage): resource.MustParse(size),
+					core.ResourceStorage: resource.MustParse(size),
 				},
 			},
 		},
@@ -56,7 +49,11 @@ func (f *Invocation) CreatePersistentVolumeClaim(pvc *core.PersistentVolumeClaim
 }
 
 func (f *Invocation) DeletePersistentVolumeClaim(meta metav1.ObjectMeta) error {
-	return f.kubeClient.CoreV1().PersistentVolumeClaims(meta.Namespace).Delete(meta.Name, nil)
+	err := f.kubeClient.CoreV1().PersistentVolumeClaims(meta.Namespace).Delete(meta.Name, nil)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 func (f *Invocation) GetVolumeSize(pvc *core.PersistentVolumeClaim) (int, error) {
@@ -92,14 +89,24 @@ func (f *Invocation) GetVolumeID(pvc *core.PersistentVolumeClaim) (int, error) {
 }
 
 func (f *Invocation) IsVolumeDetached(volumeID int) (bool, error) {
+	if volumeID <= 0 {
+		return true, nil
+	}
 	volume, err := f.linodeClient.GetVolume(context.Background(), volumeID)
 	if err != nil {
+		originalErr, ok := err.(*linodego.Error)
+		if ok && originalErr.Code == 404 {
+			return true, nil
+		}
 		return false, err
 	}
 	return volume.LinodeID == nil, err
 }
 
 func (f *Invocation) IsVolumeDeleted(volumeID int) (bool, error) {
+	if volumeID <= 0 {
+		return true, nil
+	}
 	_, err := f.linodeClient.GetVolume(context.Background(), volumeID)
 	originalErr, ok := err.(*linodego.Error)
 	if ok && originalErr.Code == 404 {

--- a/e2e/test/framework/util.go
+++ b/e2e/test/framework/util.go
@@ -7,7 +7,6 @@ import (
 	"path"
 
 	"github.com/codeskyblue/go-sh"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
@@ -29,7 +28,7 @@ func runCommand(cmd string, args ...string) error {
 	c := exec.Command(cmd, args...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	c.Env = append(c.Env, append(os.Environ())...)
+	c.Env = append(c.Env, os.Environ()...)
 	klog.Infof("Running command %v\n", cmd)
 	return c.Run()
 }


### PR DESCRIPTION
Core changes to get these running again and we should pass linting again. To get these running you can boot an LKE cluster and edit the image in the stateful/daemon set for the csi-driver to be an image you build/push to your own image repo. More updates coming to automate that a bit more.

* changed default interval to 1s to make tests run faster, still more to do but this helped cut off 2-3min
* refactored pods/pvcs to have an random int in their name, made them easier to track in kube while watching tests and hopefully we can run them all in parallel some day soon
* found dupe tests running two cleanups
* hardened the funcs around delete/detach to return errors if 404s/notfound/etc
* refactored raw block tests to be a part of the Pod + PVC test
* refactored mkfs.ext4 func to be like the other ExecInPods
* updated all tests to run in ubuntu for raw block to have mkfs.ext4 and consolidated into one GetPodObject func