### PR TITLE
Implement ListVolumes

### DIFF
--- a/pkg/linode-bs/capabilities.go
+++ b/pkg/linode-bs/capabilities.go
@@ -1,0 +1,33 @@
+package linodebs
+
+import "github.com/container-storage-interface/spec/lib/go/csi"
+
+func controllerCapabilities() []csi.ControllerServiceCapability_RPC_Type {
+	return []csi.ControllerServiceCapability_RPC_Type{
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+		// csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+		// csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
+		csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
+		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
+		csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
+	}
+}
+
+func nodeCapabilities() []csi.NodeServiceCapability_RPC_Type {
+	return []csi.NodeServiceCapability_RPC_Type{
+		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+	}
+}
+
+func volumeCapabilitiesAccessMode() []csi.VolumeCapability_AccessMode_Mode {
+	return []csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		// csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+	}
+}

--- a/pkg/linode-bs/controllerserver.go
+++ b/pkg/linode-bs/controllerserver.go
@@ -40,6 +40,9 @@ const (
 	VolumeLifecycleNodePublishVolume   VolumeLifecycle = "NodePublishVolume"
 	VolumeLifecycleNodeUnstageVolume   VolumeLifecycle = "NodeUnstageVolume"
 	VolumeLifecycleNodeUnpublishVolume VolumeLifecycle = "NodeUnpublishVolume"
+
+	// Linode Volume Topology Region Label
+	VolumeTopologyRegion string = "topology.linode.com/region"
 )
 
 type LinodeControllerServer struct {
@@ -163,7 +166,7 @@ func (linodeCS *LinodeControllerServer) CreateVolume(ctx context.Context, req *c
 			AccessibleTopology: []*csi.Topology{
 				{
 					Segments: map[string]string{
-						"topology.linode.com/region": vol.Region,
+						VolumeTopologyRegion: vol.Region,
 					},
 				},
 			},

--- a/pkg/linode-bs/controllerserver.go
+++ b/pkg/linode-bs/controllerserver.go
@@ -412,6 +412,9 @@ func (linodeCS *LinodeControllerServer) ListVolumes(ctx context.Context, req *cs
 			},
 			Status: &csi.ListVolumesResponse_VolumeStatus{
 				PublishedNodeIds: publishInfoVolumeName,
+				VolumeCondition: &csi.VolumeCondition{
+					Abnormal: false,
+				},
 			},
 		})
 	}

--- a/pkg/linode-bs/controllerserver.go
+++ b/pkg/linode-bs/controllerserver.go
@@ -395,7 +395,7 @@ func (linodeCS *LinodeControllerServer) ListVolumes(ctx context.Context, req *cs
 
 		var publishInfoVolumeName []string = make([]string, 0, 1)
 		if vol.LinodeID != nil {
-			publishInfoVolumeName = append(publishInfoVolumeName, fmt.Sprintf("%d", vol.LinodeID))
+			publishInfoVolumeName = append(publishInfoVolumeName, fmt.Sprintf("%d", *vol.LinodeID))
 		}
 
 		entries = append(entries, &csi.ListVolumesResponse_Entry{

--- a/pkg/linode-bs/controllerserver.go
+++ b/pkg/linode-bs/controllerserver.go
@@ -393,6 +393,11 @@ func (linodeCS *LinodeControllerServer) ListVolumes(ctx context.Context, req *cs
 	for _, vol := range volumes {
 		key := common.CreateLinodeVolumeKey(vol.ID, vol.Label)
 
+		var publishInfoVolumeName []string = make([]string, 0, 1)
+		if vol.LinodeID != nil {
+			publishInfoVolumeName = append(publishInfoVolumeName, fmt.Sprintf("%d", vol.LinodeID))
+		}
+
 		entries = append(entries, &csi.ListVolumesResponse_Entry{
 			Volume: &csi.Volume{
 				VolumeId:      key.GetVolumeKey(),
@@ -404,6 +409,9 @@ func (linodeCS *LinodeControllerServer) ListVolumes(ctx context.Context, req *cs
 						},
 					},
 				},
+			},
+			Status: &csi.ListVolumesResponse_VolumeStatus{
+				PublishedNodeIds: publishInfoVolumeName,
 			},
 		})
 	}

--- a/pkg/linode-bs/controllerserver.go
+++ b/pkg/linode-bs/controllerserver.go
@@ -435,29 +435,8 @@ func (linodeCS *LinodeControllerServer) ControllerGetVolume(ctx context.Context,
 
 // ControllerGetCapabilities returns the supported capabilities of controller service provided by this Plugin
 func (linodeCS *LinodeControllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	newCap := func(cap csi.ControllerServiceCapability_RPC_Type) *csi.ControllerServiceCapability {
-		return &csi.ControllerServiceCapability{
-			Type: &csi.ControllerServiceCapability_Rpc{
-				Rpc: &csi.ControllerServiceCapability_RPC{
-					Type: cap,
-				},
-			},
-		}
-	}
-
-	var caps []*csi.ControllerServiceCapability
-	for _, capability := range []csi.ControllerServiceCapability_RPC_Type{
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
-		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
-		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
-		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
-	} {
-		caps = append(caps, newCap(capability))
-	}
-
 	resp := &csi.ControllerGetCapabilitiesResponse{
-		Capabilities: caps,
+		Capabilities: linodeCS.Driver.cscap,
 	}
 
 	klog.V(4).Infoln("controller get capabilities called", map[string]interface{}{

--- a/pkg/linode-bs/controllerserver_test.go
+++ b/pkg/linode-bs/controllerserver_test.go
@@ -1,0 +1,231 @@
+package linodebs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/linode/linode-blockstorage-csi-driver/pkg/common"
+	"github.com/linode/linodego"
+)
+
+func TestListVolumes(t *testing.T) {
+	cases := map[string]struct {
+		volumes  []linodego.Volume
+		throwErr bool
+	}{
+		"volume attached to node": {
+			volumes: []linodego.Volume{
+				{
+					ID:             1,
+					Label:          "foo",
+					Status:         "",
+					Region:         "danmaaag",
+					Size:           30,
+					LinodeID:       createLinodeID(10),
+					FilesystemPath: "",
+					Tags:           []string{},
+				},
+			},
+			throwErr: false,
+		},
+		"volume not attached": {
+			volumes: []linodego.Volume{
+				{
+					ID:             1,
+					Label:          "bar",
+					Status:         "",
+					Region:         "",
+					Size:           30,
+					FilesystemPath: "",
+				},
+			},
+			throwErr: false,
+		},
+		"multiple volumes - with attachments": {
+			volumes: []linodego.Volume{
+				{
+					ID:             1,
+					Label:          "foo",
+					Status:         "",
+					Region:         "",
+					Size:           30,
+					LinodeID:       createLinodeID(5),
+					FilesystemPath: "",
+					Tags:           []string{},
+				},
+				{
+					ID:             2,
+					Label:          "foo",
+					Status:         "",
+					Region:         "",
+					Size:           60,
+					FilesystemPath: "",
+					Tags:           []string{},
+					LinodeID:       createLinodeID(10),
+				},
+			},
+			throwErr: false,
+		},
+		"multiple volumes - mixed attachments": {
+			volumes: []linodego.Volume{
+				{
+					ID:             1,
+					Label:          "foo",
+					Status:         "",
+					Region:         "",
+					Size:           30,
+					LinodeID:       createLinodeID(5),
+					FilesystemPath: "",
+					Tags:           []string{},
+				},
+				{
+					ID:             2,
+					Label:          "foo",
+					Status:         "",
+					Region:         "",
+					Size:           30,
+					FilesystemPath: "",
+					Tags:           []string{},
+					LinodeID:       nil,
+				},
+			},
+			throwErr: false,
+		},
+		"Linode API error": {
+			volumes:  nil,
+			throwErr: true,
+		},
+	}
+
+	for c, tt := range cases {
+		t.Run(c, func(t *testing.T) {
+			cs := &LinodeControllerServer{
+				CloudProvider: &fakeLinodeClient{
+					volumes:  tt.volumes,
+					throwErr: tt.throwErr,
+				},
+			}
+
+			listVolsResp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{})
+			if err != nil {
+				if !tt.throwErr {
+					t.Fatalf("test case got unexpected err: %s", err)
+				}
+				return
+			}
+
+			for _, entry := range listVolsResp.Entries {
+				gotVol := entry.GetVolume()
+				if gotVol == nil {
+					t.Fatal("vol was nil")
+				}
+
+				var wantVol *linodego.Volume
+				for _, v := range tt.volumes {
+					v := v
+					// The issue is that the ID returned is
+					// not the same as what is passed in
+					key := common.CreateLinodeVolumeKey(v.ID, v.Label)
+					if gotVol.VolumeId == key.GetVolumeKey() {
+						wantVol = &v
+						break
+					}
+				}
+
+				if wantVol == nil {
+					t.Fatalf("failed to find input volume equivalent to: %#v", gotVol)
+				}
+
+				if gotVol.CapacityBytes != int64(wantVol.Size)*gigabyte {
+					t.Errorf("volume size not equal, got: %d, want: %d", gotVol.CapacityBytes, wantVol.Size*gigabyte)
+				}
+
+				for _, i := range gotVol.GetAccessibleTopology() {
+					region, ok := i.Segments[VolumeTopologyRegion]
+					if !ok {
+						t.Errorf("got empty region")
+					}
+
+					if region != wantVol.Region {
+						t.Errorf("regions do not match, got: %s, want: %s", region, wantVol.Region)
+					}
+				}
+
+				status := entry.GetStatus()
+				if status == nil {
+					t.Fatal("status was nil")
+				}
+
+				if status.VolumeCondition.Abnormal {
+					t.Errorf("got abnormal volume condition")
+				}
+
+				if len(status.GetPublishedNodeIds()) > 1 {
+					t.Errorf("volume was published on more than 1 node, got: %s", status.GetPublishedNodeIds())
+				}
+
+				switch publishedNodes := status.GetPublishedNodeIds(); {
+				case len(publishedNodes) == 0 && wantVol.LinodeID == nil:
+				// This case is fine - having it here prevents a segfault if we try to index into publishedNodes in the last case
+				case len(publishedNodes) == 0 && wantVol.LinodeID != nil:
+					t.Errorf("expected volume to be attached, got: %s, want: %d", status.GetPublishedNodeIds(), *wantVol.LinodeID)
+				case len(publishedNodes) != 0 && wantVol.LinodeID == nil:
+					t.Errorf("expected volume to be unattached, got: %s", publishedNodes)
+				case publishedNodes[0] != fmt.Sprintf("%d", *wantVol.LinodeID):
+					t.Fatalf("got: %s, want: %d published node id", status.GetPublishedNodeIds()[0], *wantVol.LinodeID)
+				}
+			}
+		})
+
+	}
+
+}
+
+type fakeLinodeClient struct {
+	volumes  []linodego.Volume
+	throwErr bool
+}
+
+func (flc *fakeLinodeClient) ListInstances(context.Context, *linodego.ListOptions) ([]linodego.Instance, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) ListVolumes(context.Context, *linodego.ListOptions) ([]linodego.Volume, error) {
+	if flc.throwErr {
+		return nil, errors.New("sad times mate")
+	}
+	return flc.volumes, nil
+}
+func (flc *fakeLinodeClient) GetInstance(context.Context, int) (*linodego.Instance, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) GetVolume(context.Context, int) (*linodego.Volume, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) CreateVolume(context.Context, linodego.VolumeCreateOptions) (*linodego.Volume, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) CloneVolume(context.Context, int, string) (*linodego.Volume, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) AttachVolume(context.Context, int, *linodego.VolumeAttachOptions) (*linodego.Volume, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) DetachVolume(context.Context, int) error { return nil }
+func (flc *fakeLinodeClient) WaitForVolumeLinodeID(context.Context, int, *int, int) (*linodego.Volume, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) WaitForVolumeStatus(context.Context, int, linodego.VolumeStatus, int) (*linodego.Volume, error) {
+	return nil, nil
+}
+func (flc *fakeLinodeClient) DeleteVolume(context.Context, int) error      { return nil }
+func (flc *fakeLinodeClient) ResizeVolume(context.Context, int, int) error { return nil }
+func (flc *fakeLinodeClient) NewEventPoller(context.Context, any, linodego.EntityType, linodego.EventAction) (*linodego.EventPoller, error) {
+	return nil, nil
+}
+
+func createLinodeID(i int) *int {
+	return &i
+}

--- a/pkg/linode-bs/driver.go
+++ b/pkg/linode-bs/driver.go
@@ -89,6 +89,7 @@ func (linodeDriver *LinodeDriver) SetupLinodeDriver(linodeClient linodeclient.Li
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
+		csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
 	}
 	if err := linodeDriver.AddControllerServiceCapabilities(csc); err != nil {
 		return err

--- a/pkg/linode-bs/driver.go
+++ b/pkg/linode-bs/driver.go
@@ -73,33 +73,15 @@ func (linodeDriver *LinodeDriver) SetupLinodeDriver(linodeClient linodeclient.Li
 	linodeDriver.bsPrefix = bsPrefix
 
 	// Adding Capabilities
-	vcam := []csi.VolumeCapability_AccessMode_Mode{
-		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-		// csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
-	}
+	vcam := volumeCapabilitiesAccessMode()
 	if err := linodeDriver.AddVolumeCapabilityAccessModes(vcam); err != nil {
 		return err
 	}
-	csc := []csi.ControllerServiceCapability_RPC_Type{
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
-		// csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
-		// csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
-		csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
-		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
-		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
-		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
-		csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
-	}
+	csc := controllerCapabilities()
 	if err := linodeDriver.AddControllerServiceCapabilities(csc); err != nil {
 		return err
 	}
-	ns := []csi.NodeServiceCapability_RPC_Type{
-		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
-		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
-		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
-		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
-	}
+	ns := nodeCapabilities()
 	if err := linodeDriver.AddNodeServiceCapabilities(ns); err != nil {
 		return err
 	}

--- a/pkg/linode-bs/driver.go
+++ b/pkg/linode-bs/driver.go
@@ -88,6 +88,7 @@ func (linodeDriver *LinodeDriver) SetupLinodeDriver(linodeClient linodeclient.Li
 		csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 	}
 	if err := linodeDriver.AddControllerServiceCapabilities(csc); err != nil {
 		return err

--- a/pkg/linode-bs/driver.go
+++ b/pkg/linode-bs/driver.go
@@ -97,6 +97,7 @@ func (linodeDriver *LinodeDriver) SetupLinodeDriver(linodeClient linodeclient.Li
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
 	}
 	if err := linodeDriver.AddNodeServiceCapabilities(ns); err != nil {
 		return err


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)


Advertises the capability for Controller ListVolumes which resolves #59 . Allows us to run the `external-health-monitor` and get volume health stats for our PVCs. 

The PR also consolidates the places where our driver capabilities are set as I spent far too much time wondering why the change in [ae2665ea54](https://github.com/linode/linode-blockstorage-csi-driver/pull/144/commits/ae2665ea54dc418c4522b505cf229c6376b5a109) wasn't being advertised. Furthermore, this meant that we weren't actually advertising the ability to mount 

## Testing

Testing this feature requires running the external-health-monitor. I chose to run it as part of the linode controller but we can run it as a separate deployment using leader election. 

1. Update the `deploy/kubernetes/base/ss-csi-linode-controller.yaml` with the following extra container and set the csi-driver to my image. The `deploy/kubernetes/base/ds-csi-linode-node.yaml` should also have it's plugin image update. 
```yaml
- name: external-health-monitor
    image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
    args:
      - "-v=5"
      - "-csi-address=$(ADDRESS)"
      - "-enable-node-watcher=true"
      - "-http-endpoint=:8080"
      - "-metrics-path=/metrics"
    env:
      - name: ADDRESS
        value: /var/lib/csi/sockets/pluginproxy/csi.sock
    volumeMounts:
    - name: socket-dir
      mountPath: /var/lib/csi/sockets/pluginproxy/
    ports:
      - containerPort: 8080
        name: metrics
  - name: linode-csi-plugin
    image: ghcr.io/avestuk/linode-blockstorage-csi-driver:v0.6.0-20-gc06d64a-dirty
```
2. Create a PVC and consume it from a Pod - check that the external health monitor logs reflect volume creation
3. Update the kubelet config to enable the `CSIVolumeHealth` feature gate
3. Check the node metrics data and see that `volumeHealthStatus` is now being reported. 
kubectl get --raw "/api/v1/nodes/lke145862-214328-13bc36d60000/proxy/stats/summary"
```json
    {
     "time": "2023-12-11T14:25:42Z",
     "availableBytes": 10445123584,
     "capacityBytes": 10464022528,
     "usedBytes": 2121728,
     "inodesFree": 655348,
     "inodes": 655360,
     "inodesUsed": 12,
     "name": "csi-example-volume",
     "pvcRef": {
      "name": "csi-example-pvc",
      "namespace": "kube-system"
     },
     "volumeHealthStats": {
      "abnormal": false
     }
    }
```

