### PR TITLE
fix: Respect imagePullPolicy for driver in CSI controller StatefulSet

### DIFF
--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -81,6 +81,7 @@ spec:
               name: {{ if .Values.secretRef }}{{ .Values.secretRef.name | default "linode" }}{{ else }}"linode"{{ end }}
               key: {{ if .Values.secretRef }}{{ .Values.secretRef.apiTokenRef | default "token" }}{{ else }}"token"{{ end }}
         image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.csiLinodePlugin.pullPolicy }}
         name: linode-csi-plugin
         volumeMounts:
         - mountPath: /linode-info


### PR DESCRIPTION
### General:

This change addresses a small oversight in the Helm chart's csi-linode-controller StatefulSet.
