### PR TITLE
add ability to configure the pods mount dir to the helm chart

### DIFF
--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -72,7 +72,7 @@ spec:
           name: get-linode-id
         - mountPath: /csi
           name: plugin-dir
-        - mountPath: /var/lib/kubelet
+        - mountPath: {{ .Values.csiLinodePlugin.podsMountDir }}
           mountPropagation: Bidirectional
           name: pods-mount-dir
         - mountPath: /dev
@@ -132,7 +132,7 @@ spec:
           type: DirectoryOrCreate
         name: plugin-dir
       - hostPath:
-          path: /var/lib/kubelet
+          path: {{ .Values.csiLinodePlugin.podsMountDir }}
           type: Directory
         name: pods-mount-dir
       - hostPath:

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -44,6 +44,7 @@ csiLinodePlugin:
   image: linode/linode-blockstorage-csi-driver
   tag: # only set if required, defaults to .Chart.AppVersion set during release or "latest" by default
   pullPolicy: IfNotPresent
+  podsMountDir: /var/lib/kubelet
 
 kubectl:
   image: alpine/k8s # This needs to be alpine based and have both kubectl and curl installed.


### PR DESCRIPTION
Adds a param to configure the pods-mount-dir for the csi plugin daemonset 
