### PR TITLE
LKE-3931: Set maxVolumesPerNode to 7

### DIFF
--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	maxVolumesPerNode = 8
+	maxVolumesPerNode = 7
 )
 
 type LinodeNodeServer struct {


### PR DESCRIPTION
This is a quick fix for the default case when we have 8 slots and one slot is already taken by boot disk. There may be more slots in use by non-PVC volumes such as swap but they are not the default in LKE.

fixes #154

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

