### PR TITLE
Ensure that LinodeID matches before detach.

### DIFF
--- a/pkg/linode-bs/controllerserver.go
+++ b/pkg/linode-bs/controllerserver.go
@@ -309,6 +309,9 @@ func (linodeCS *LinodeControllerServer) ControllerUnpublishVolume(ctx context.Co
 
 	volume, err := linodeCS.CloudProvider.GetVolume(ctx, volumeID)
 	if err != nil {
+		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code == 404 {
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if volume.LinodeID != nil && *volume.LinodeID != linodeID {

--- a/pkg/linode-bs/controllerserver.go
+++ b/pkg/linode-bs/controllerserver.go
@@ -307,6 +307,15 @@ func (linodeCS *LinodeControllerServer) ControllerUnpublishVolume(ctx context.Co
 		"method":    "controller_unpublish_volume",
 	})
 
+	volume, err := linodeCS.CloudProvider.GetVolume(ctx, volumeID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if volume.LinodeID != nil && *volume.LinodeID != linodeID {
+		klog.V(4).Infof("volume is attached to %d, not to %d, skipping", *volume.LinodeID, linodeID)
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+
 	if err := linodeCS.CloudProvider.DetachVolume(ctx, volumeID); err != nil {
 		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code == 404 {
 			return &csi.ControllerUnpublishVolumeResponse{}, nil


### PR DESCRIPTION
Avoid calling detach when Volume is assigned to different LinodeID.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

