### PR TITLE
Write encryptionKey to crypsetup stdin

### DIFF
--- a/pkg/linode-bs/luks.go
+++ b/pkg/linode-bs/luks.go
@@ -64,31 +64,21 @@ func (ctx *LuksContext) validate() error {
 		return nil
 	}
 
-	appendFn := func(x string, xs string) string {
-		if xs != "" {
-			xs += "; "
-		}
-		xs += x
-		return xs
-	}
-
-	errorMsg := ""
+	var err error
 	if ctx.VolumeName == "" {
-		errorMsg = appendFn("no volume name provided", errorMsg)
+		err = errors.Join(err, fmt.Errorf("no volume name provided"))
 	}
 	if ctx.EncryptionKey == "" {
-		errorMsg = appendFn("no encryption key provided", errorMsg)
+		err = errors.Join(err, fmt.Errorf("no encryption key provided"))
 	}
 	if ctx.EncryptionCipher == "" {
-		errorMsg = appendFn("no encryption cipher provided", errorMsg)
+		err = errors.Join(err, fmt.Errorf("no encryption cipher provided"))
 	}
 	if ctx.EncryptionKeySize == "" {
-		errorMsg = appendFn("no encryption key size provided", errorMsg)
+		err = errors.Join(err, fmt.Errorf("no encryption key size provided"))
 	}
-	if errorMsg == "" {
-		return nil
-	}
-	return errors.New(errorMsg)
+
+	return err
 }
 
 func getLuksContext(secrets map[string]string, context map[string]string, lifecycle VolumeLifecycle) LuksContext {

--- a/pkg/linode-bs/luks.go
+++ b/pkg/linode-bs/luks.go
@@ -114,7 +114,7 @@ func getLuksContext(secrets map[string]string, context map[string]string, lifecy
 	}
 }
 
-func luksFormat(source string, ctx LuksContext) error {
+func luksFormat(ctx LuksContext, source string) error {
 	cryptsetupCmd, err := getCryptsetupCmd()
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func luksFormat(source string, ctx LuksContext) error {
 
 	// open the luks partition
 	klog.V(4).Info("luksOpen ", source)
-	err = luksOpen(source, ctx)
+	err = luksOpen(ctx, source)
 	if err != nil {
 		return fmt.Errorf("cryptsetup luksOpen failed: %v cmd: '%s %s' output: %q",
 			err, cryptsetupCmd, strings.Join(cryptsetupArgs, " "), string(out))
@@ -174,8 +174,8 @@ func luksFormat(source string, ctx LuksContext) error {
 }
 
 // prepares a luks-encrypted volume for mounting and returns the path of the mapped volume
-func luksPrepareMount(source string, ctx LuksContext) (string, error) {
-	if err := luksOpen(source, ctx); err != nil {
+func luksPrepareMount(ctx LuksContext, source string) (string, error) {
+	if err := luksOpen(ctx, source); err != nil {
 		return "", err
 	}
 	return "/dev/mapper/" + ctx.VolumeName, nil
@@ -198,7 +198,7 @@ func luksClose(volume string) error {
 	return nil
 }
 
-func luksOpen(volume string, ctx LuksContext) error {
+func luksOpen(ctx LuksContext, volume string) error {
 	// check if the luks volume is already open
 	if _, err := os.Stat("/dev/mapper/" + ctx.VolumeName); !os.IsNotExist(err) {
 		klog.V(4).Infof("luks volume is already open %s", volume)

--- a/pkg/linode-bs/luks.go
+++ b/pkg/linode-bs/luks.go
@@ -140,10 +140,12 @@ func luksFormat(source string, ctx LuksContext) error {
 	}
 
 	if _, err := io.WriteString(stdin, ctx.EncryptionKey); err != nil {
-		stdin.Close()
-		return fmt.Errorf("failed to write to stdin pipe for cryptsetup, got err: %s", err)
+		return fmt.Errorf("failed to write to stdin pipe for cryptsetup, got err: %s, closing pipe: %s", err, stdin.Close())
 	}
-	stdin.Close()
+
+	if err := stdin.Close(); err != nil {
+		return fmt.Errorf("failed to close stdin pipe, got err: %s", err)
+	}
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -222,10 +224,12 @@ func luksOpen(volume string, ctx LuksContext) error {
 	}
 
 	if _, err := io.WriteString(stdin, ctx.EncryptionKey); err != nil {
-		stdin.Close()
-		return fmt.Errorf("failed to write to stdin pipe for cryptsetup, got err: %s", err)
+		return fmt.Errorf("failed to write to stdin pipe for cryptsetup, got err: %s, closing pipe: %s", err, stdin.Close())
 	}
-	stdin.Close()
+
+	if err := stdin.Close(); err != nil {
+		return fmt.Errorf("failed to close stdin pipe, got err: %s", err)
+	}
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/linode-bs/luks.go
+++ b/pkg/linode-bs/luks.go
@@ -66,16 +66,16 @@ func (ctx *LuksContext) validate() error {
 
 	var err error
 	if ctx.VolumeName == "" {
-		err = errors.Join(err, fmt.Errorf("no volume name provided"))
+		err = errors.Join(err, errors.New("no volume name provided"))
 	}
 	if ctx.EncryptionKey == "" {
-		err = errors.Join(err, fmt.Errorf("no encryption key provided"))
+		err = errors.Join(err, errors.New("no encryption key provided"))
 	}
 	if ctx.EncryptionCipher == "" {
-		err = errors.Join(err, fmt.Errorf("no encryption cipher provided"))
+		err = errors.Join(err, errors.New("no encryption cipher provided"))
 	}
 	if ctx.EncryptionKeySize == "" {
-		err = errors.Join(err, fmt.Errorf("no encryption key size provided"))
+		err = errors.Join(err, errors.New("no encryption key size provided"))
 	}
 
 	return err

--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -310,12 +310,12 @@ func (ns *LinodeNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeSt
 			if err := luksContext.validate(); err != nil {
 				return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to luks format validation (%q): %v", devicePath, err))
 			}
-			if err := luksFormat(devicePath, luksContext); err != nil {
+			if err := luksFormat(luksContext, devicePath); err != nil {
 				return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to luks format (%q): %v", devicePath, err))
 			}
 		}
 
-		luksSource, err := luksPrepareMount(devicePath, luksContext)
+		luksSource, err := luksPrepareMount(luksContext, devicePath)
 		if err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to prepare luks mount (%q): %v", devicePath, err))
 		}


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

Provides a fix for #158 by providing the encryption key on stdin rather than writing it to disk. This eliminates the requirement for `/tmp` to be a tmpfs as we just don't write the key to disk at all. 

I've also made a few other changes to make the code a little more idiomatic. 

Adding unit tests is doable - cryptsetup will create a loopback device if [we target a file instead of a block device](https://man7.org/linux/man-pages/man8/cryptsetup.8.html), we'd need to make further changes in order to make the functions unit testable. I'll raise a separate issue for doing this. 

Can be tested using following manifests and the container ghcr.io/avestuk/linode-blockstorage-csi-driver:helm-v0.6.3-5-g763d4d2

```
apiVersion: v1
data:
  luksKey: aERFS0ZnRVpnbXB1cHBTaFBHN0hhaWxTRkJzeThNemx2bGhBTHZxazArMmpUcmNLckZtdHR0b0Y1SUdsTFZvTHQvanBhV25rL2tjbDdKeG5zWjN4UWpFY1l1bXY0V2t3T3Y3N3grYzJDL2t5eWxkVE5SYUNhVkhHOWZXOW42b2ljb1d6c3lVV2NtdTBkK0pPb3JHWjc5MmxzUzlRNWdYbENnNUJEMngxTW9WVnI4aFRRQXJGZlVYNk51SEYxbzB2L0VHSFUwQTVPNXdpTm5xcGREamY5cjU2clB0MEgyOTBOcjZZNUlqYjVSVElvSkZUNXd3NVhvY3J2TGxSL0dpWFJZZ3plSVNmYmZ5SXI4RnBmUkttalBUWmRMQlNYUE1NZEhKTmNQSWxSRytEZm5CYVRLa0lGd2lXWGp4WFpzczcxSUtpYkVNN1FmandrYTBLRnl1ZndBPT0=
kind: Secret
metadata:
  name: csi-encrypt-example-luks-key
  namespace: kube-system
type: Opaque
---
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: linode-block-storage-retain-luks
  namespace: kube-system
provisioner: linodebs.csi.linode.com
reclaimPolicy: Retain
parameters:
  linodebs.csi.linode.com/luks-encrypted: "true"
  linodebs.csi.linode.com/luks-cipher: "aes-xts-plain64"
  linodebs.csi.linode.com/luks-key-size: "512"
  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
  csi.storage.k8s.io/node-stage-secret-name: csi-encrypt-example-luks-key
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-example-pvcluks
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: linode-block-storage-retain-luks
---
kind: Pod
apiVersion: v1
metadata:
  name: csi-example-pod
spec:
  containers:
    - name: csi-example-container
      image: busybox
      volumeMounts:
      - mountPath: "/data"
        name: csi-example-volume
      command: [ "sleep", "1000000" ]
  volumes:
    - name: csi-example-volume
      persistentVolumeClaim:
        claimName: csi-example-pvcluks
```

Logs showing successful running of commands shown below
```
csi-linode-node-blg44 csi-linode-plugin I0312 12:21:51.224221       1 nodeserver.go:302] luksContext encryption enabled
csi-linode-node-blg44 csi-linode-plugin I0312 12:21:51.228082       1 nodeserver.go:308] luks volume now formatting: /dev/disk/by-id/scsi-0Linode_Volume_pvc8f834f890a3e4f54
csi-linode-node-blg44 csi-linode-plugin I0312 12:21:51.228137       1 luks.go:133] executing cryptsetup luksFormat command [-v --batch-mode --cipher aes-xts-plain64 --key-size 512 --key-file - luksFormat /dev/disk/by-id/scsi-0Linode_Volume_pvc8f834f890a3e4f54]
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:02.409794       1 luks.go:155] luksOpen /dev/disk/by-id/scsi-0Linode_Volume_pvc8f834f890a3e4f54
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:02.409977       1 luks.go:216] executing cryptsetup luksOpen command
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:04.305369       1 luks.go:169] The LUKS volume name is pvc8f834f890a3e4f54
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:04.305420       1 luks.go:189] executing cryptsetup close command
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:04.529456       1 luks.go:216] executing cryptsetup luksOpen command
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:06.446573       1 nodeserver.go:324] formatting and mounting the drive
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:06.446607       1 mount_linux.go:405] Attempting to determine if disk "/dev/mapper/pvc8f834f890a3e4f54" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/mapper/pvc8f834f890a3e4f54])
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:06.456620       1 mount_linux.go:408] Output: "", err: exit status 2
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:06.456643       1 mount_linux.go:366] Disk "/dev/mapper/pvc8f834f890a3e4f54" appears to be unformatted, attempting to format as type: "ext4" with options: [-F -m0 /dev/mapper/pvc8f834f890a3e4f54]
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:06.612352       1 mount_linux.go:376] Disk successfully formatted (mkfs): ext4 - /dev/mapper/pvc8f834f890a3e4f54 /var/lib/kubelet/plugins/kubernetes.io/csi/linodebs.csi.linode.com/85d5758976a0c19a22a7181ef751e09337459838984d7476c1a9cb4281d688e9/globalmount
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:06.612655       1 mount_linux.go:394] Attempting to mount disk /dev/mapper/pvc8f834f890a3e4f54 in ext4 format at /var/lib/kubelet/plugins/kubernetes.io/csi/linodebs.csi.linode.com/85d5758976a0c19a22a7181ef751e09337459838984d7476c1a9cb4281d688e9/globalmount
csi-linode-node-blg44 csi-linode-plugin I0312 12:22:06.613505       1 mount_linux.go:146] Mounting cmd (mount) with arguments (-t ext4 -o defaults /dev/mapper/pvc8f834f890a3e4f54 /var/lib/kubelet/plugins/kubernetes.io/csi/linodebs.csi.linode.com/85d5758976a0c19a22a7181ef751e09337459838984d7476c1a9cb4281d688e9/globalmount)
```
