### PR TITLE
fix: handle bind mounts on same device as expected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         run: make lint
       - name: Test
         run: make test
+      - name: Test (elevated)
+        run: make elevated-test
       - name: Build
         run: make build
   docker-build:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ lint: vet
 test: vet verify
 	go test -v ./... -cover $(TEST_ARGS)
 
+.PHONY: elevated-test
+elevated-test:
+	sudo go test -v ./... -cover -tags=elevated $(TEST_ARGS)
+
 .PHONY: build
 build:
 	go build -o linode-blockstorage-csi-driver -a -ldflags '-X main.vendorVersion='${REV}' -extldflags "-static"' ./main.go

--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -198,7 +198,7 @@ func (ns *LinodeNodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.No
 		return nil, status.Error(codes.InvalidArgument, "NodeUnpublishVolume Target Path must be provided")
 	}
 
-	err := mount.CleanupMountPoint(targetPath, ns.Mounter.Interface, false /* bind mount */)
+	err := mount.CleanupMountPoint(targetPath, ns.Mounter.Interface, true /* bind mount */)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Unmount failed: %v\nUnmounting arguments: %s\n", err, targetPath))
 	}
@@ -346,7 +346,7 @@ func (ns *LinodeNodeServer) NodeUnstageVolume(ctx context.Context, req *csi.Node
 		return nil, status.Error(codes.InvalidArgument, "NodeUnstageVolume Staging Target Path must be provided")
 	}
 
-	err := mount.CleanupMountPoint(stagingTargetPath, ns.Mounter.Interface, false /* bind mount */)
+	err := mount.CleanupMountPoint(stagingTargetPath, ns.Mounter.Interface, true /* bind mount */)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeUnstageVolume failed to unmount at path %s: %v", stagingTargetPath, err))
 	}

--- a/pkg/linode-bs/nodeserver_test.go
+++ b/pkg/linode-bs/nodeserver_test.go
@@ -1,0 +1,124 @@
+//go:build linux && elevated
+// +build linux,elevated
+
+package linodebs_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	linodebs "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-bs"
+	mountmanager "github.com/linode/linode-blockstorage-csi-driver/pkg/mount-manager"
+	"k8s.io/utils/exec"
+	"k8s.io/utils/mount"
+)
+
+func newSafeMounter() *mount.SafeFormatAndMount {
+	realMounter := mount.New("")
+	realExec := exec.New()
+	return &mount.SafeFormatAndMount{
+		Interface: realMounter,
+		Exec:      realExec,
+	}
+}
+
+var (
+	defaultNodeServer = &linodebs.LinodeNodeServer{Mounter: mountmanager.NewSafeMounter()}
+
+	defaultTeardownFunc = func(t *testing.T, mount string) {
+		_, err := os.Stat(mount)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return
+			}
+
+			t.Errorf("failed to stat the '%s': %v", mount, err)
+			return
+		}
+
+		// best effort call, no need to check error
+		_ = defaultNodeServer.Mounter.Unmount(mount)
+
+		err = os.RemoveAll(path.Dir(mount))
+		if err != nil {
+			t.Errorf("failed to remove the '%s': %v", path.Dir(mount), err)
+		}
+	}
+
+	defaultPrepareFunc = func() (string, func(*testing.T, string), error) {
+		root, err := os.MkdirTemp("", "")
+		if err != nil {
+			return "", nil, fmt.Errorf("mkdir temp failed: %w", err)
+		}
+
+		source := path.Join(root, "source")
+		target := path.Join(root, "target")
+
+		err = os.Mkdir(source, 0o755)
+		if err != nil {
+			return "", nil, fmt.Errorf("mkdir '%s' failed: %w", source, err)
+		}
+
+		err = os.Mkdir(target, 0o755)
+		if err != nil {
+			return "", nil, fmt.Errorf("mkdir '%s' failed: %w", target, err)
+		}
+
+		defaultNodeServer.Mounter.Mount(source, target, "ext4", []string{"bind"})
+
+		return target, defaultTeardownFunc, nil
+	}
+)
+
+func TestNodeUnstageUnpublishVolume(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		prepareFunc func() (string, func(*testing.T, string), error)
+		call        func(string) error
+	}{
+		{
+			name:        "unstage_bind_mount_regression",
+			prepareFunc: defaultPrepareFunc,
+			call: func(target string) error {
+				req := &csi.NodeUnstageVolumeRequest{
+					VolumeId:          "test",
+					StagingTargetPath: target,
+				}
+
+				_, err := defaultNodeServer.NodeUnstageVolume(context.TODO(), req)
+				return err
+			},
+		},
+		{
+			name:        "unpublish_bind_mount_regression",
+			prepareFunc: defaultPrepareFunc,
+			call: func(target string) error {
+				req := &csi.NodeUnpublishVolumeRequest{
+					VolumeId:   "test",
+					TargetPath: target,
+				}
+
+				_, err := defaultNodeServer.NodeUnpublishVolume(context.TODO(), req)
+				return err
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			target, teardownFunc, err := tc.prepareFunc()
+			if err != nil {
+				t.Errorf("failed to prepare test: %v", err)
+				return
+			}
+			defer teardownFunc(t, target)
+
+			if err = tc.call(target); err != nil {
+				t.Errorf("failed to unstage volume: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

**NOTE:** The code change is causing performance regression, as additional checks must be performed when checking if the target is a mount point. This is necessary, as that's how we can reliably detect the bind mounts.
