### PR TITLE
Luks e2e

### DIFF
--- a/e2e/test/csi_driver_test.go
+++ b/e2e/test/csi_driver_test.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	"e2e_test/test/framework"
 	"fmt"
 	"math/rand"
 	"strconv"
+
+	"e2e_test/test/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/e2e/test/e2e_suite_test.go
+++ b/e2e/test/e2e_suite_test.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"k8s.io/client-go/util/homedir"
 
 	"github.com/linode/linodego"
-
-	"path/filepath"
 
 	"e2e_test/test/framework"
 
@@ -44,9 +43,7 @@ func init() {
 	flag.StringVar(&region, "region", region, "Region to create cluster in")
 }
 
-var (
-	root *framework.Framework
-)
+var root *framework.Framework
 
 func TestE2e(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -116,7 +113,7 @@ var _ = AfterSuite(func() {
 	By("Deleting Namespace " + root.Namespace())
 	err := root.DeleteNamespace(root.Namespace())
 	Expect(err).NotTo(HaveOccurred())
-	if !(useExisting || reuse) {
+	if !useExisting && !reuse {
 		By("Deleting cluster")
 		err := framework.DeleteCluster(clusterName)
 		Expect(err).NotTo(HaveOccurred())

--- a/e2e/test/framework/storageclass.go
+++ b/e2e/test/framework/storageclass.go
@@ -1,0 +1,74 @@
+package framework
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const driverName = "linodebs.csi.linode.com"
+
+func (f *Framework) CreateStorageClass(sc *v1.StorageClass) error {
+	_, err := f.kubeClient.StorageV1().StorageClasses().Create(sc)
+
+	return err
+}
+
+// DeleteStorageClass returns a storage class that can be subsequently created. The parameters can be obtained using GetLuksParameters
+func (f *Framework) DeleteStorageClass(name string) error {
+	return f.kubeClient.StorageV1().StorageClasses().Delete(name, &metav1.DeleteOptions{})
+}
+
+// GetStorageClass returns a storage class that can be subsequently created. The parameters can be obtained using GetLuksParameters
+func (f *Framework) GetStorageClass(name string, parameters map[string]string) *v1.StorageClass {
+	return &v1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner:          driverName,
+		Parameters:           parameters,
+		ReclaimPolicy:        ptrT(corev1.PersistentVolumeReclaimDelete),
+		AllowVolumeExpansion: ptrT(true),
+	}
+}
+
+func (f *Framework) GetLuksParameters(secretName, secretNamespace string) map[string]string {
+	return map[string]string{
+		"linodebs.csi.linode.com/luks-encrypted":         "true",
+		"linodebs.csi.linode.com/luks-cipher":            "aes-xts-plain64",
+		"linodebs.csi.linode.com/luks-key-size":          "512",
+		"csi.storage.k8s.io/node-stage-secret-namespace": secretNamespace,
+		"csi.storage.k8s.io/node-stage-secret-name":      secretName,
+	}
+}
+
+// CreateLuksSecret creates a secret containing a valid  LUKS key. The namespace is optional and defaults to kube-system as the secret must be readable by the CSI controller.
+// TODO: Currently the key is static but we could and should generate them dynamically.
+func (f *Framework) CreateLuksSecret(name string, namespace ...string) error {
+	ns := "kube-system"
+	if len(namespace) > 0 {
+		ns = namespace[0]
+	}
+
+	_, err := f.kubeClient.CoreV1().Secrets(ns).Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string][]byte{
+			"luksKey": []byte("aERFS0ZnRVpnbXB1cHBTaFBHN0hhaWxTRkJzeThNemx2bGhBTHZxazArMmpUcmNLckZtdHR0b0Y1SUdsTFZvTHQvanBhV25rL2tjbDdKeG5zWjN4UWpFY1l1bXY0V2t3T3Y3N3grYzJDL2t5eWxkVE5SYUNhVkhHOWZXOW42b2ljb1d6c3lVV2NtdTBkK0pPb3JHWjc5MmxzUzlRNWdYbENnNUJEMngxTW9WVnI4aFRRQXJGZlVYNk51SEYxbzB2L0VHSFUwQTVPNXdpTm5xcGREamY5cjU2clB0MEgyOTBOcjZZNUlqYjVSVElvSkZUNXd3NVhvY3J2TGxSL0dpWFJZZ3plSVNmYmZ5SXI4RnBmUkttalBUWmRMQlNYUE1NZEhKTmNQSWxSRytEZm5CYVRLa0lGd2lXWGp4WFpzczcxSUtpYkVNN1FmandrYTBLRnl1ZndBPT0="),
+		},
+		StringData: map[string]string{},
+		Type:       "",
+	})
+
+	return err
+}
+
+func (f *Framework) DeleteLuksSecret(name string, namespace ...string) error {
+	ns := "kube-system"
+	if len(namespace) > 0 {
+		ns = namespace[0]
+	}
+
+	return f.kubeClient.CoreV1().Secrets(ns).Delete(name, &metav1.DeleteOptions{})
+}

--- a/e2e/test/framework/util.go
+++ b/e2e/test/framework/util.go
@@ -44,3 +44,7 @@ func ApplyManifest(commandName, manifest string) error {
 	log.Println(string(out))
 	return err
 }
+
+func ptrT[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)


Addresses the lack of tests in #159 - Creating loopback devices in docker was sadly not as straight forward as I had hoped and I wasn't able to get something working. Given the ease with which we can now write e2e tests thanks to #163 and @mhmxs an e2e test should afford us a better level of comfort. 

Currently this PR is set as a draft to get some initial commentary back on the overall approach. Mainly I'm not enamoured with using static names for the LUKS storageClass and Secrets and the subsequent cleanup that has to happen. I don't think that there is an issue in modifying the "global" `storageClass` as ginkgo does parallelism using separate processes so mutation of `storageClass` in one process will not affect others. 

Breaking this out into a separate `Describe` node would work but would require copying `JustBeforeEach` or moving it to a function and substantially altering the tests. I would like to add additional LUKS tests to show that LUKS volumes require a proper AES-XTS key in order to function, there may well be other tests we would like to add such as LUKS volume expansion etc. 
