### PR TITLE
pkg/linode-bs: Do not persist volume attachments across boots

### DIFF
--- a/pkg/linode-bs/limits.go
+++ b/pkg/linode-bs/limits.go
@@ -1,0 +1,31 @@
+package linodebs
+
+// maxVolumeAttachments returns the maximum number of block storage volumes
+// that can be attached to a Linode instance, given the amount of memory the
+// instance has.
+//
+// TODO: This code should be cleaned up to use the built-in max and min
+// functions once the project is updated to Go 1.21. See
+// https://go.dev/ref/spec#Min_and_max.
+func maxVolumeAttachments(memoryBytes uint) int {
+	attachments := memoryBytes >> 30
+	if attachments > maxAttachments {
+		return maxAttachments
+	}
+	if attachments < maxPersistentAttachments {
+		return maxPersistentAttachments
+	}
+	return int(attachments)
+}
+
+const (
+	// maxPersistentAttachments is the default number of volume attachments
+	// allowed when they are persisted to an instance/boot config. This is
+	// also the maximum number of allowed volume attachments when the
+	// instance type has < 16GiB of RAM.
+	maxPersistentAttachments = 8
+
+	// maxAttachments it the hard limit of volumes that can be attached to
+	// a single Linode instance.
+	maxAttachments = 64
+)

--- a/pkg/linode-bs/limits_test.go
+++ b/pkg/linode-bs/limits_test.go
@@ -1,0 +1,39 @@
+package linodebs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMaxVolumeAttachments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		memory uint
+		want   int
+	}{
+		{memory: 1 << 30, want: maxPersistentAttachments},
+		{memory: 2 << 30, want: maxPersistentAttachments},
+		{memory: 4 << 30, want: maxPersistentAttachments},
+		{memory: 8 << 30, want: maxPersistentAttachments},
+		{memory: 16 << 30, want: 16},
+		{memory: 32 << 30, want: 32},
+		{memory: 64 << 30, want: maxAttachments},
+		{memory: 96 << 30, want: maxAttachments},
+		{memory: 128 << 30, want: maxAttachments},
+		{memory: 150 << 30, want: maxAttachments},
+		{memory: 256 << 30, want: maxAttachments},
+		{memory: 300 << 30, want: maxAttachments},
+		{memory: 512 << 30, want: maxAttachments},
+	}
+
+	for _, tt := range tests {
+		tname := fmt.Sprintf("%dGB", tt.memory>>30)
+		t.Run(tname, func(t *testing.T) {
+			got := maxVolumeAttachments(tt.memory)
+			if got != tt.want {
+				t.Errorf("want=%d got=%d", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/linode-bs/nodeserver.go
+++ b/pkg/linode-bs/nodeserver.go
@@ -35,10 +35,6 @@ import (
 	"k8s.io/utils/mount"
 )
 
-const (
-	maxVolumesPerNode = 7
-)
-
 type LinodeNodeServer struct {
 	Driver          *LinodeDriver
 	Mounter         *mount.SafeFormatAndMount
@@ -246,7 +242,6 @@ func (ns *LinodeNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeSt
 	deviceName := key.GetNormalizedLabel()
 	devicePaths := ns.DeviceUtils.GetDiskByIdPaths(deviceName, partition)
 	devicePath, err := ns.DeviceUtils.VerifyDevicePath(devicePaths)
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Error verifying Linode Volume (%q) is attached: %v", key.GetVolumeLabel(), err))
 	}
@@ -409,11 +404,10 @@ func (ns *LinodeNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInf
 
 	resp := &csi.NodeGetInfoResponse{
 		NodeId:             strconv.Itoa(nodeID),
-		MaxVolumesPerNode:  maxVolumesPerNode,
+		MaxVolumesPerNode:  int64(maxVolumeAttachments(ns.MetadataService.Memory())),
 		AccessibleTopology: top,
 	}
 	return resp, nil
-
 }
 
 func (ns *LinodeNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {

--- a/pkg/linode-client/linode-client.go
+++ b/pkg/linode-client/linode-client.go
@@ -12,6 +12,8 @@ import (
 type LinodeClient interface {
 	ListInstances(context.Context, *linodego.ListOptions) ([]linodego.Instance, error) // Needed for metadata
 	ListVolumes(context.Context, *linodego.ListOptions) ([]linodego.Volume, error)
+	ListInstanceVolumes(ctx context.Context, instanceID int, options *linodego.ListOptions) ([]linodego.Volume, error)
+	ListInstanceDisks(ctx context.Context, instanceID int, options *linodego.ListOptions) ([]linodego.InstanceDisk, error)
 
 	GetInstance(context.Context, int) (*linodego.Instance, error)
 	GetVolume(context.Context, int) (*linodego.Volume, error)


### PR DESCRIPTION
When attaching a block storage volume to a Linode, by default, the Linode API will attempt to persist the attachment across instance reboots by adding the volume ID to the currently-booted instance configuration. This will limit the number of volumes that can be attached to 8, as instance configurations currently only allow attaching local disks and block storage volumes to `sda`..`sdh`.

This change explicitly disables persisting volume attachments across instance boots, when a block storage volume is attached to a running Linode instance. It also adds a pre-attachment check to see if another volume can be attached based on the amount of memory of the host.

The maximum number of volumes that can be attached to a single Linode instance is clamped between 8 and 64, with the allowed number of volume attachments matching the amount of memory allocated to the Linode, in gigabytes. In other words, Linodes with <= 8GiB of RAM can have a maximum of 8 volumes attached; Linodes with 16GiB of RAM can have 16 volumes attached; Linodes with > 64GiB of RAM are limited to 64 volume attachments.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

