### PR TITLE
ci: Use go.mod for selecting the Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,13 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [ 'stable', 'oldstable' ]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - name: Vet
         run: make vet
       - name: Lint


### PR DESCRIPTION
The "ci" workflow was previously using the "stable" and "oldstable" versions, which as of Go 1.22 introduces a slight change in how go.mod is formatted. This results in errors like

	go: updates to go.mod needed; to update it:
		go mod tidy

in the workflow logs.

So instead of relying on mutable version labels like "stable" and "oldstable", this commit binds the version of Go used in CI to be what is specified in the repository's go.mod file.

This will allow us the ability to gradually update Go versions without needing to change the version in more than one place, and keep CI predictable.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

