### PR TITLE
Configure the CSI driver through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,33 @@
 [![Test](https://github.com/linode/linode-blockstorage-csi-driver/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/linode/linode-blockstorage-csi-driver/actions/workflows/test.yml) [![Docker build](https://github.com/linode/linode-blockstorage-csi-driver/actions/workflows/docker-hub.yml/badge.svg?branch=master)](https://github.com/linode/linode-blockstorage-csi-driver/actions/workflows/docker-hub.yml)
 
 ## Overview
-The Container Storage Interface ([CSI](https://github.com/container-storage-interface/spec)) Driver for Linode Block Storage enables container orchestrators such as Kubernetes to manage the life-cycle of persistent storage claims.
+The Container Storage Interface
+([CSI](https://github.com/container-storage-interface/spec)) Driver for Linode
+Block Storage enables container orchestrators such as Kubernetes to manage the
+life-cycle of persistent storage claims.
 
-More information about the Kubernetes CSI can be found in the GitHub [Kubernetes CSI](https://kubernetes-csi.github.io/docs/example.html) and [CSI Spec](https://github.com/container-storage-interface/spec/) repos.
+More information about the Kubernetes CSI can be found in the GitHub [Kubernetes
+CSI](https://kubernetes-csi.github.io/docs/example.html) and [CSI
+Spec](https://github.com/container-storage-interface/spec/) repositories.
 
 ## Deployment
 
-There are two ways of deploying CSI. The recommended way is to use Helm and second way is to use manually set secrets on the kubernetes cluster then use kubectl to deploy using the given [`yaml` file](https://raw.githubusercontent.com/linode/linode-blockstorage-csi-driver/master/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml). 
+There are two ways of deploying CSI.
+The recommended way is to use Helm.
+The second way is to use manually set secrets on the kubernetes cluster then use
+kubectl to deploy using the given [`yaml`
+file](https://raw.githubusercontent.com/linode/linode-blockstorage-csi-driver/master/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml). 
 
 ### Requirements
 * Kubernetes v1.16+
-* [LINODE_API_TOKEN](https://cloud.linode.com/profile/tokens) (See 'Secure a Linode API Access Token' below).
+* [LINODE_API_TOKEN](https://cloud.linode.com/profile/tokens) (See 'Secure a
+  Linode API Access Token' below).
 * Linode [REGION](https://api.linode.com/v4/regions).
 
 
 ### Secure a Linode API Access Token:
-Generate a Personal Access Token (PAT) using the [Linode Cloud Manager](https://cloud.linode.com/profile/tokens).
+Generate a Personal Access Token (PAT) using the [Linode Cloud
+Manager](https://cloud.linode.com/profile/tokens).
 
 This token will need:
 
@@ -26,62 +37,79 @@ This token will need:
 * A sufficient "Expiry" to allow for continued use of your volumes
 
 ### [Recommended] Using Helm to deploy the CSI Driver
-LINODE_API_TOKEN must be a Linode APIv4 [Personal Access Token](https://cloud.linode.com/profile/tokens) with Volume and Linode permissions.
 
-REGION must be a Linode [region](https://api.linode.com/v4/regions).
+`LINODE_API_TOKEN` must be a Linode APIv4 [Personal Access
+Token](https://cloud.linode.com/profile/tokens) with Volume and Linode
+permissions.
+
+`REGION` must be a Linode [region](https://api.linode.com/v4/regions).
 
 #### Install the csi-linode repo
-```shell
+
+```sh
 helm repo add linode-csi https://linode.github.io/linode-blockstorage-csi-driver/   
 helm repo update linode-csi
 ```
 
 #### To deploy the CSI Driver
-```sh
-export LINODE_API_TOKEN=<linodeapitoken>
-export REGION=<linoderegion>
 
-helm install linode-csi-driver --set apiToken=$LINODE_API_TOKEN,region=$REGION linode-csi/linode-blockstorage-csi-driver
+```sh
+export LINODE_API_TOKEN="...your Linode API token..."
+export REGION="your preferred region"
+
+helm install linode-csi-driver \
+  --set apiToken="${LINODE_API_TOKEN}" \
+  --set region="${REGION}" \
+  linode-csi/linode-blockstorage-csi-driver
 ```
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-#### To uninstall linode-csi-driver from kubernetes cluster. Run the following command:
+#### Uninstalling linode-blockstorage-csi-driver
+
+To uninstall the linode-blockstorage-csi-driver from your cluster, run the
+following command:
+
 ```sh
 helm uninstall linode-csi-driver
 ```
-_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command
+documentation._
 
-#### To upgrade when new changes are made to the helm chart. Run the following command:
+#### Upgrading linode-blockstorage-csi-driver
+
+To upgrade when new changes are made to the helm chart, run the following
+command:
+
 ```sh
-export LINODE_API_TOKEN=<linodeapitoken>
-export REGION=<linoderegion>
+export LINODE_API_TOKEN="...your Linode API token..."
+export REGION="your preferred region"
 
-helm upgrade linode-csi-driver --install --set apiToken=$LINODE_API_TOKEN,region=$REGION linode-csi/linode-blockstorage-csi-driver
+helm upgrade linode-csi-driver \
+  --install \
+  --set apiToken="${LINODE_API_TOKEN}" \
+  --set region="${REGION}" \
+  linode-csi/linode-blockstorage-csi-driver
 ```
-_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command
+documentation._
 
 #### Configurations
 
-There are other variables that can be set to a different value. For list of all the modifiable variables/values, take a look at './helm-chart/csi-driver/values.yaml'. 
+There are other variables that can be set to a different value.
+For list of all the modifiable variables/values, see
+[helm-chart/csi-driver/values.yaml](https://github.com/linode/linode-blockstorage-csi-driver/blob/main/helm-chart/csi-driver/values.yaml).
 
-Values can be set/overrided by using the '--set var=value,...' flag or by passing in a custom-values.yaml using '-f custom-values.yaml'.
+Values can be set/overrided by using the '--set var=value,...' flag or by
+passing in a custom-values.yaml using '-f custom-values.yaml'.
 
-Recommendation: Use custom-values.yaml to override the variables to avoid any errors with template rendering
+Recommendation: Use a custom `values.yaml` file to override the variables to
+avoid any errors with template rendering.
 
+### Deploying with kubectl
 
-### Using Kubectl to deploy CSI
+#### Create a secret
 
-#### Create a kubernetes secret:
-
-Run the following commands to stash a `LINODE_TOKEN` in your Kubernetes cluster:
-
-```bash
-read -s -p "Linode API Access Token: " LINODE_TOKEN
-read -p "Linode Region of Cluster: " LINODE_REGION
-cat <<EOF | kubectl create -f -
-```
-
-Paste the following text at the prompt:
+Create the following secret:
 
 ```yaml
 apiVersion: v1
@@ -90,61 +118,98 @@ metadata:
   name: linode
   namespace: kube-system
 stringData:
-  token: "$LINODE_TOKEN"
-  region: "$LINODE_REGION"
-EOF
+  token: "your linode api token"
+  region: "your preferred region"
 ```
 
-You should receive notification that the secret was created.  You can confirm this by running:
+then apply it with 
 
 ```sh
-$ kubectl -n kube-system get secrets
-NAME                  TYPE                                  DATA      AGE
-linode          Opaque                                2         18h
+kubectl apply -f secret.yaml
 ```
 
-#### Deploying CSI through kubectl:
+You should receive notification that the secret was created.
+You can confirm this by running:
 
-The following command will deploy the latest version of the CSI driver with all related Kubernetes volume attachment, driver registration, and provisioning sidecars:
+```sh
+$ kubectl -n kube-system get secret/linode
+NAME    TYPE      DATA      AGE
+linode  Opaque    2         2m
+```
+
+#### Deploy the CSI driver
+
+The following command will deploy the latest version of the CSI driver with all
+related Kubernetes volume attachment, driver registration, and provisioning
+sidecars:
 
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/linode/linode-blockstorage-csi-driver/master/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver.yaml
 ```
 
-If you need a specific [release](https://github.com/linode/linode-blockstorage-csi-driver/releases) of the CSI driver you can specify the release version in the URL like the following:
+If you need a specific
+[release](https://github.com/linode/linode-blockstorage-csi-driver/releases) of
+the CSI driver you can specify the release version in the URL like the
+following:
 
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/linode/linode-blockstorage-csi-driver/master/pkg/linode-bs/deploy/releases/linode-blockstorage-csi-driver-v0.5.3.yaml
 ```
 
-This deployment is a concatenation of all of the `yaml` files in [pkg/linode-bs/deploy/kubernetes/](https://github.com/linode/linode-blockstorage-csi-driver/tree/master/pkg/linode-bs/deploy/kubernetes/).
+This deployment is a concatenation of all of the `yaml` files in
+[pkg/linode-bs/deploy/kubernetes/](https://github.com/linode/linode-blockstorage-csi-driver/tree/master/pkg/linode-bs/deploy/kubernetes/).
 
 Notably, this deployment will:
 
-* set the default storage class to `linode-block-storage-retain` [Learn More](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/)
+* Set the default storage class to `linode-block-storage-retain` [Learn
+  More](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/)
 
-  This behavior can be modified in the [csi-storageclass.yaml](https://github.com/linode/linode-blockstorage-csi-driver/blob/master/pkg/linode-bs/deploy/kubernetes/05-csi-storageclass.yaml) section of the deployment by toggling the `storageclass.kubernetes.io/is-default-class` annotation.
+  This behavior can be modified in the
+  [csi-storageclass.yaml](https://github.com/linode/linode-blockstorage-csi-driver/blob/master/pkg/linode-bs/deploy/kubernetes/05-csi-storageclass.yaml)
+  section of the deployment by toggling the
+  `storageclass.kubernetes.io/is-default-class` annotation.
 
   ```sh
   $ kubectl get storageclasses
-  NAME                             PROVISIONER               AGE
+  NAME                                    PROVISIONER               AGE
   linode-block-storage-retain (default)   linodebs.csi.linode.com   2d
   linode-block-storage                    linodebs.csi.linode.com   2d
   ```
 
-* use a `reclaimPolicy` of `Retain` [Learn More](https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/)
+* Use a `reclaimPolicy` of `Retain` [Learn
+  More](https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/)
 
-  Volumes created by this CSI driver will default to using the `linode-block-storage-retain` storage class if one is not specified. Upon deletion of all PersitentVolumeClaims, the PersistentVolume and its backing Block Storage Volume will remain intact.
+  Volumes created by this CSI driver will default to using the
+  `linode-block-storage-retain` storage class if one is not specified.
+  Upon deletion of all PersitentVolumeClaims, the PersistentVolume and its
+  backing Block Storage Volume will remain intact.
 
-* assume that the [Linode CCM](https://github.com/linode/linode-cloud-controller-manager) is initialized and running [Learn More](https://kubernetes.io/docs/reference/command-line-tools-reference/cloud-controller-manager/)
+* Assume that the [Linode
+  CCM](https://github.com/linode/linode-cloud-controller-manager) is initialized
+  and running [Learn More](https://kubernetes.io/docs/reference/command-line-tools-reference/cloud-controller-manager/)
 
-  If you absolutely intend to run this on a cluster which will not run the Linode CCM, you must modify the init container script located in the `08-cm-get-linode-id.yaml` ConfigMap and delete [the line](https://github.com/linode/linode-blockstorage-csi-driver/blob/master/pkg/linode-bs/deploy/kubernetes/08-cm-get-linode-id.yaml#L19) that contains the `exit 1`.
+  If you absolutely intend to run this on a cluster which will not run the
+  Linode CCM, you must modify the init container script located in the
+  `08-cm-get-linode-id.yaml` ConfigMap and delete [the
+  line](https://github.com/linode/linode-blockstorage-csi-driver/blob/master/pkg/linode-bs/deploy/kubernetes/08-cm-get-linode-id.yaml#L19)
+  that contains the `exit 1`.
 
 ### Example Usage
 
-This repository contains [two manifests](https://github.com/linode/linode-blockstorage-csi-driver/tree/master/pkg/linode-bs/examples/kubernetes) that demonstrate use of the Linode BlockStorage CSI.  These manifests will create a PersistentVolume Claim using the `linode-block-storage-retain` storage class and then consume it in a minimal pod.
+This repository contains [two
+manifests](https://github.com/linode/linode-blockstorage-csi-driver/tree/master/pkg/linode-bs/examples/kubernetes)
+that demonstrate use of the Linode BlockStorage CSI.
+These manifests will create a PersistentVolume Claim using the
+`linode-block-storage-retain` storage class and then consume it in a minimal
+pod.
 
-Once you have installed the Linode BlockStorage CSI, the following commands will run the example.  Once you are finished with the example, please be sure to delete the pod, PVC, and the associated Block Storage Volume. The PVC created in this example uses the `linode-block-storage-retain` storage class, so you will need to remove the Block Storage Volume from your Linode account via the Cloud Manager or the Linode CLI.
+Once you have installed the Linode BlockStorage CSI, the following commands will
+run the example.
+Once you are finished with the example, please be sure to delete the pod, PVC,
+and the associated Block Storage Volume.
+The PVC created in this example uses the `linode-block-storage-retain` storage
+class, so you will need to remove the Block Storage Volume from your Linode
+account via the Cloud Manager or the Linode CLI.
 
 ```sh
 kubectl create -f https://raw.githubusercontent.com/linode/linode-blockstorage-csi-driver/master/pkg/linode-bs/examples/kubernetes/csi-pvc.yaml
@@ -155,17 +220,25 @@ Verify that the pod is running and can consume the volume:
 
 ```sh
 kubectl get pvc/csi-example-pvc pods/csi-example-pod
-kubectl describe pvc/csi-example-pvc pods/csi-example-pod | less
+kubectl describe pvc/csi-example-pvc pods/csi-example-pod
 ```
 
-Now, let's add some data into the PVC, delete the POD, and recreate the pod.  Our data will remain intact.
+Now, let's add some data into the PVC, and delete and recreate the pod.
+Our data will remain intact.
+
+First, we will write some data to a file in the PVC:
 
 ```sh
 $ kubectl exec -it csi-example-pod -- /bin/sh -c "echo persistence > /data/example.txt; ls -l /data"
 total 20
 -rw-r--r--    1 root     root            12 Dec  5 13:06 example.txt
 drwx------    2 root     root         16384 Dec  5 06:03 lost+found
+```
 
+Then we will delete and recreate the pod, and check to make sure our data is
+still there:
+
+```sh
 $ kubectl delete pods/csi-example-pod
 pod "csi-example-pod" deleted
 
@@ -181,18 +254,30 @@ persistence
 ```
 
 ### Encrypted Drives using LUKS
-The ability to encrypt a PVC with a user owned secret provides an additional security layer that gives control of the data to the cluster owner instead of the platform provider.
+
+The ability to encrypt a PVC with a user owned secret provides an additional
+security layer that gives control of the data to the cluster owner instead of
+the platform provider.
 
 #### Notes
+
 1.  Resize is possible with similar steps to resizing PVCs on LKE and are
     not handled by driver.  Need cryptSetup resize + resize2fs on LKE node.
-2.  Key rotation process is not handled by driver but is possible via similar steps to out of band resize operations.
+2.  Key rotation process is not handled by driver but is possible via similar
+    steps to out of band resize operations.
 3.  Encryption is only possible on a new/empty PVC.
-4.  LUKS key is currently pulled from a native Kubernetes secret.  Take note of how your cluster handles secrets in etcd.  The CSI driver is careful to otherwise keep the secret on an ephemeral tmpfs mount and otherwise refuses to continue.
+4.  LUKS key is currently pulled from a native Kubernetes secret.
+    Take note of how your cluster handles secrets in etcd.
+    The CSI driver is careful to otherwise keep the secret on an ephemeral tmpfs
+    mount and otherwise refuses to continue.
 
 #### Example StorageClass
-*Note* To use an encryption key per PVC you can make a new StorageClass/Secret combination each time.
-```
+
+> [!TIP]
+> To use an encryption key per PVC you can make a new StorageClass/Secret
+> combination each time.
+
+```yaml
 allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -219,9 +304,9 @@ stringData:
   luksKey: "SECRETGOESHERE"  
 ```
 
-#### Example PVC.
+#### Example PVC
 
-```
+```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -247,11 +332,15 @@ spec:
   storageClassName: linode-block-storage-retain-luks
 ```
 ### Adding Tags to created volumes
-This feature gives users the ability to add tags to volumes created by a specific storageClass, to allow for better tracking of volumes.
-Tags are added as a comma seperated string value for a parameter `linodebs.csi.linode.com/volumeTags`
+
+This feature gives users the ability to add tags to volumes created by a
+specific storageClass, to allow for better tracking of volumes.
+Tags are added as a comma seperated string value for a parameter
+`linodebs.csi.linode.com/volumeTags`
 
 #### Example StorageClass
-```
+
+```yaml
 allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -268,15 +357,28 @@ parameters:
 
 ## Disclaimers
 
-* Until this driver has reached v1.0.0 it may not maintain compatibility between driver versions
-* Requests for Persistent Volumes with a `require_size` less than the Linode minimum Block Storage size will be fulfilled with a Linode Block Storage volume of the minimum size (currently 10GiB), this is [in accordance with the CSI specification](https://github.com/container-storage-interface/spec/blob/v1.0.0/spec.md#createvolume).  The upper-limit size constraint (`limit_bytes`) will also be honored so the size of Linode Block Storage volumes provisioned will not exceed this parameter.
+* Until this driver has reached v1.0.0 it may not maintain compatibility between
+  driver versions.
+* Requests for Persistent Volumes with a `require_size` less than the Linode
+  minimum Block Storage size will be fulfilled with a Linode Block Storage volume
+  of the minimum size (currently `10Gi`).
+  This is [in accordance with the CSI
+  specification](https://github.com/container-storage-interface/spec/blob/v1.0.0/spec.md#createvolume).
+  The upper-limit size constraint (`limit_bytes`) will also be honored so the
+  size of Linode Block Storage volumes provisioned will not exceed this
+  parameter.
 
 ## Contribution Guidelines
 
-Want to improve the linode-blockstorage-csi-driver? Please start [here](.github/CONTRIBUTING.md).
+Want to improve the linode-blockstorage-csi-driver?
+Please start [here](.github/CONTRIBUTING.md).
 
 ## Join us on Slack
 
-For general help or discussion, join the [Kubernetes Slack](http://slack.k8s.io/) channel [#linode](https://kubernetes.slack.com/messages/CD4B15LUR).
+For general help or discussion, join the [Kubernetes
+Slack](http://slack.k8s.io/) channel
+[#linode](https://kubernetes.slack.com/messages/CD4B15LUR).
 
-For development and debugging, join the [Gopher's Slack](https://invite.slack.golangbridge.org/) channel [#linodego](https://gophers.slack.com/messages/CAG93EB2S).
+For development and debugging, join the [Gopher's
+Slack](https://invite.slack.golangbridge.org/) channel
+[#linodego](https://gophers.slack.com/messages/CAG93EB2S).

--- a/deploy/kubernetes/base/ds-csi-linode-node.yaml
+++ b/deploy/kubernetes/base/ds-csi-linode-node.yaml
@@ -57,15 +57,11 @@ spec:
         - name: csi-linode-plugin
           image: linode/linode-blockstorage-csi-driver:latest
           args :
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--token=$(LINODE_TOKEN)"
-            - "--url=$(LINODE_API_URL)"
-            - "--node=$(NODE_NAME)"
             - "--v=2"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            - name: LINODE_API_URL
+            - name: LINODE_URL
               value: https://api.linode.com/v4
             - name: NODE_NAME
               valueFrom:

--- a/deploy/kubernetes/base/ss-csi-linode-controller.yaml
+++ b/deploy/kubernetes/base/ss-csi-linode-controller.yaml
@@ -77,16 +77,11 @@ spec:
         - name: linode-csi-plugin
           image: linode/linode-blockstorage-csi-driver:latest
           args:
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--token=$(LINODE_TOKEN)"
-            - "--url=$(LINODE_API_URL)"
-            - "--node=$(NODE_NAME)"
-            - "--bs-prefix=$(LINODE_BS_PREFIX)"
             - "--v=2"
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: LINODE_API_URL
+            - name: LINODE_URL
               value: https://api.linode.com/v4
             - name: LINODE_BS_PREFIX
             - name: NODE_NAME

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/container-storage-interface/spec v1.3.0
+	github.com/ianschenck/envflag v0.0.0-20140720210342-9111d830d133
 	github.com/linode/go-metadata v0.2.0
 	github.com/linode/linodego v1.23.0
 	golang.org/x/net v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/ianschenck/envflag v0.0.0-20140720210342-9111d830d133 h1:h6FO/Da7rdYqJbRYMW9f+SMBWnJVguWh+0ERefW8zp8=
+github.com/ianschenck/envflag v0.0.0-20140720210342-9111d830d133/go.mod h1:pyYc5lldRtL0l5YitYVv1dLKuC0qhMfAfiR7BLsN2pA=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -58,17 +58,14 @@ spec:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
-        - --endpoint=$(CSI_ENDPOINT)
-        - --token=$(LINODE_TOKEN)
-        - --url=$(LINODE_API_URL)
-        - --bs-prefix=$(LINODE_BS_PREFIX)
         - --v=2
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-        - name: LINODE_API_URL
+        - name: LINODE_URL
           value: https://api.linode.com/v4
-        - name: LINODE_BS_PREFIX
+        - name: LINODE_VOLUME_LABEL_PREFIX
+          value: {{ .Values.volumeLabelPrefix | default "" | quote }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -37,14 +37,11 @@ spec:
         - mountPath: /registration
           name: registration-dir
       - args:
-        - --endpoint=$(CSI_ENDPOINT)
-        - --token=$(LINODE_TOKEN)
-        - --url=$(LINODE_API_URL)
         - --v=2
         env:
         - name: CSI_ENDPOINT
           value: unix:///csi/csi.sock
-        - name: LINODE_API_URL
+        - name: LINODE_URL
           value: https://api.linode.com/v4
         - name: NODE_NAME
           valueFrom:

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -5,6 +5,10 @@ apiToken: ""
 # region [Required if secretRef is not set] - Must be a Linode region. (https://api.linode.com/v4/regions)
 region: ""
 
+# (OPTIONAL) Label prefix for the Linode Block Storage volumes created by this
+# driver.
+volumeLabelPrefix: ""
+
 # Default namespace is "kube-system" but it can be set to another namespace
 namespace: kube-system
 


### PR DESCRIPTION
Within the Helm chart templates, the containers running `linode-blockstorage-csi-driver` were being configured with command-line flags where the flags' values were coming from environment variables. This commit removes the middle-man, and drops all of the CSI driver-specific command-line flags in favour of reading configuration values directly from the environment.
    
The Helm chart and kustomize templates have been updated accordingly.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

