### PR TITLE
Add golangci-lint configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Vet
-        run: make vet
-      - name: Lint
-        run: make lint
-      - name: Test
-        run: make test
-      - name: Test (elevated)
-        run: make elevated-test
-      - name: Build
-        run: make build
+      - run: make build
+      - run: go vet ./...
+      - uses: dominikh/staticcheck-action@v1
+        with:
+          version: latest
+          install-go: false
+      - run: go test -cover ./...
+      - run: make elevated-test
   docker-build:
     runs-on: ubuntu-latest
     steps:

--- a/.golanci.yml
+++ b/.golanci.yml
@@ -1,0 +1,155 @@
+run:
+  timeout: 5m
+  issues-exit-code: 1
+
+output:
+  formats: colored-line-number
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+
+  gci:
+    sections:
+      - standard
+      - default
+      - blank
+      - dot
+      - prefix(github.com/linode)
+
+  govet:
+    check-shadowing: false
+
+  golint:
+    min-confidence: 0.8
+
+  gofmt:
+    simplify: true
+
+  goimports:
+    local-prefixes: github.com/linode/
+
+  maligned:
+    suggest-new: true
+
+  dupl:
+    threshold: 100
+
+  goconst:
+    min-len: 3
+    min-occurrences: 3
+
+  prealloc:
+    simple: true
+    range-loops: true
+    for-loops: true
+
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+
+    settings:
+      captLocal:
+        paramsOnly: true
+      rangeValCopy:
+        sizeThreshold: 32
+
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+
+  varnamelen:
+    min-name-length: 2
+
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidicheck
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - decorder
+    - dogsled
+    - dupl
+    - dupword
+    - durationcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - gci
+    - gocheckcompilerdirectives
+    - gocognit
+    - goconst
+    - gocritic
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - ineffassign
+    - loggercheck
+    - maintidx
+    - makezero
+    - misspell
+    - mnd
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - parlalleltest
+    - prealloc
+    - predeclared
+    - reassign
+    - tenv
+    - thelper
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - varnamelen
+    - whitespace
+
+  presets:
+    - bugs
+    - unused
+
+  fast: false
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - maintidx
+        - dupl
+        - exportloopref
+
+    - text: "G101:"
+      linters:
+        - gosec
+        - gas
+
+    - text: "G104:"
+      linters:
+        - gosec
+        - gas
+
+  exclude-use-default: false
+  new: false
+  max-per-linter: 0
+  max-same-issues: 0
+  exclude-files:
+    - "zz_generated\\..+\\.go$"


### PR DESCRIPTION
The golangci-lint configuration file contains some customized linter configurations, simply because not all of the linters that are enabled by default are worth it.

The "ci" workflow has also been modified a little. Namely, building the binary is done first as a quick and inexpensive check. If it successfully builds, then we go on to do the full-bore vet, staticcheck, linting, and tests.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

