### PR TITLE
internal/driver: Simplify set up of driver capabilities

### DIFF
--- a/internal/driver/capabilities.go
+++ b/internal/driver/capabilities.go
@@ -2,32 +2,67 @@ package driver
 
 import "github.com/container-storage-interface/spec/lib/go/csi"
 
-func controllerCapabilities() []csi.ControllerServiceCapability_RPC_Type {
-	return []csi.ControllerServiceCapability_RPC_Type{
+// ControllerServiceCapabilities returns the list of capabilities supported by
+// this driver's controller service.
+func ControllerServiceCapabilities() []*csi.ControllerServiceCapability {
+	capabilities := []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
-		// csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
-		// csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 		csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 		csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
 	}
+
+	cc := make([]*csi.ControllerServiceCapability, 0, len(capabilities))
+	for _, c := range capabilities {
+		cc = append(cc, &csi.ControllerServiceCapability{
+			Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: c,
+				},
+			},
+		})
+	}
+	return cc
 }
 
-func nodeCapabilities() []csi.NodeServiceCapability_RPC_Type {
-	return []csi.NodeServiceCapability_RPC_Type{
+// NodeServiceCapabilities returns the list of capabilities supported by this
+// driver's node service.
+func NodeServiceCapabilities() []*csi.NodeServiceCapability {
+	capabilities := []csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
 	}
+
+	cc := make([]*csi.NodeServiceCapability, 0, len(capabilities))
+	for _, c := range capabilities {
+		cc = append(cc, &csi.NodeServiceCapability{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: c,
+				},
+			},
+		})
+	}
+	return cc
 }
 
-func volumeCapabilitiesAccessMode() []csi.VolumeCapability_AccessMode_Mode {
-	return []csi.VolumeCapability_AccessMode_Mode{
+// VolumeCapabilityAccessModes returns the allowed access modes for a volume
+// created by the driver.
+func VolumeCapabilityAccessModes() []*csi.VolumeCapability_AccessMode {
+	modes := []csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-		// csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
 	}
+
+	mm := make([]*csi.VolumeCapability_AccessMode, 0, len(modes))
+	for _, m := range modes {
+		mm = append(mm, &csi.VolumeCapability_AccessMode{
+			Mode: m,
+		})
+	}
+	return mm
 }

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -8,13 +8,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/container-storage-interface/spec/lib/go/csi"
 	linodeclient "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-client"
 	mountmanager "github.com/linode/linode-blockstorage-csi-driver/pkg/mount-manager"
 
@@ -72,32 +70,6 @@ func TestDriverSuite(t *testing.T) {
 	linodeDriver := GetLinodeDriver()
 	if err := linodeDriver.SetupLinodeDriver(fakeCloudProvider, mounter, deviceUtils, md, driver, vendorVersion, bsPrefix); err != nil {
 		t.Fatalf("Failed to setup Linode Driver: %v", err)
-	}
-
-	// Validate Capabilities are as expected
-	wantControllerCaps := []*csi.ControllerServiceCapability{}
-	for _, cscap := range controllerCapabilities() {
-		wantControllerCaps = append(wantControllerCaps, NewControllerServiceCapability(cscap))
-	}
-
-	if !reflect.DeepEqual(linodeDriver.cscap, wantControllerCaps) {
-		t.Errorf("controller capabilities are not as expected, got:\n%v\nwant:%v", linodeDriver.cscap, wantControllerCaps)
-	}
-
-	wantNodeCaps := []*csi.NodeServiceCapability{}
-	for _, nscap := range nodeCapabilities() {
-		wantNodeCaps = append(wantNodeCaps, NewNodeServiceCapability(nscap))
-	}
-	if !reflect.DeepEqual(linodeDriver.nscap, wantNodeCaps) {
-		t.Errorf("node capabilities are not as expected, got:\n%v\nwant:%v", linodeDriver.nscap, wantNodeCaps)
-	}
-
-	wantVolumeCapAccessMode := []*csi.VolumeCapability_AccessMode{}
-	for _, vcap := range volumeCapabilitiesAccessMode() {
-		wantVolumeCapAccessMode = append(wantVolumeCapAccessMode, NewVolumeCapabilityAccessMode(vcap))
-	}
-	if !reflect.DeepEqual(linodeDriver.vcap, wantVolumeCapAccessMode) {
-		t.Errorf("volume capabilities are not as expected, got:\n%v\nwant:%v", linodeDriver.vcap, volumeCapabilitiesAccessMode())
 	}
 
 	go linodeDriver.Run(endpoint)

--- a/internal/driver/utils.go
+++ b/internal/driver/utils.go
@@ -17,35 +17,10 @@ limitations under the License.
 package driver
 
 import (
-	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 )
-
-func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability_AccessMode {
-	return &csi.VolumeCapability_AccessMode{Mode: mode}
-}
-
-func NewControllerServiceCapability(cap csi.ControllerServiceCapability_RPC_Type) *csi.ControllerServiceCapability {
-	return &csi.ControllerServiceCapability{
-		Type: &csi.ControllerServiceCapability_Rpc{
-			Rpc: &csi.ControllerServiceCapability_RPC{
-				Type: cap,
-			},
-		},
-	}
-}
-
-func NewNodeServiceCapability(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeServiceCapability {
-	return &csi.NodeServiceCapability{
-		Type: &csi.NodeServiceCapability_Rpc{
-			Rpc: &csi.NodeServiceCapability_RPC{
-				Type: cap,
-			},
-		},
-	}
-}
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	klog.V(3).Infof("GRPC call: %s", info.FullMethod)


### PR DESCRIPTION
The driver's capabilities were currently split up across several functions, across several files. This change consolidates all of the capabilities handling into one function per capability type (controller, node, volume access modes).

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

