### PR TITLE
Fix script to look at just the id

### DIFF
--- a/helm-chart/csi-driver/templates/get-linode-id.yaml
+++ b/helm-chart/csi-driver/templates/get-linode-id.yaml
@@ -23,7 +23,7 @@ data:
       # Try to get ID using Metadata API with a 5-second timeout
       TOKEN=$(curl -sS -m 5 -X PUT -H "Metadata-Token-Expiry-Seconds: 3600" $META_API/token || true)
       if [ ! -z "$TOKEN" ]; then
-        ID=$(curl -sS -m 5 -H "Metadata-Token: $TOKEN" $META_API/instance -H "Accept: application/json" | grep -o '"id": [0-9]*' | cut -d' ' -f2 |  tr -d '\n' || true)
+        ID=$(curl -sS -m 5 -H "Metadata-Token: $TOKEN" $META_API/instance -H "Accept: application/json" | jq -r .id |  tr -d '\n' || true)
         echo "Metadata linode ID was $ID"
       fi
     fi

--- a/helm-chart/csi-driver/templates/get-linode-id.yaml
+++ b/helm-chart/csi-driver/templates/get-linode-id.yaml
@@ -23,7 +23,7 @@ data:
       # Try to get ID using Metadata API with a 5-second timeout
       TOKEN=$(curl -sS -m 5 -X PUT -H "Metadata-Token-Expiry-Seconds: 3600" $META_API/token || true)
       if [ ! -z "$TOKEN" ]; then
-        ID=$(curl -sS -m 5 -H "Metadata-Token: $TOKEN" $META_API/instance | grep -v "uuid" | awk -F': ' '/id:/{print $2}'  | tr -d '\n' || true)
+        ID=$(curl -sS -m 5 -H "Metadata-Token: $TOKEN" $META_API/instance -H "Accept: application/json" | grep -o '"id": [0-9]*' | cut -d' ' -f2 |  tr -d '\n' || true)
         echo "Metadata linode ID was $ID"
       fi
     fi


### PR DESCRIPTION
### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?
The get-linode-id script can produce a mangled linode-id when there's a tag with a `id` in there. For example with a metadata response like this
```
backups.enabled: true
backups.status: pending
host_uuid: 2d56ceffafec9f76be86e1d2d1dd37ec2204b28f
id: 60586846
label: jkvbpzyzqaa9pj8ix-master-0
region: us-ord
specs.disk: 163840
specs.gpus: 0
specs.memory: 8192
specs.transfer: 5000
specs.vcpus: 4
tags: cluster:kpp-api-single
tags: clusterUid:jkvbpzyzqaa9pj8ix
tags: prov-from:mgmt-cluster.akamai-kpp.com
type: g6-standard-4
```
the script ends up with
```
60586846clusterUid:jkvbpzyzqaa9pj8i
```

This fixes it by explictly asking for json and looking only at the "id" param.

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

