### PR TITLE
internal/driver: Rename and export the driver name

### DIFF
--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -21,7 +21,6 @@ type VolumeLifecycle string
 
 const (
 	gigabyte               = 1024 * 1024 * 1024
-	driverName             = "linodebs.csi.linode.com"
 	devicePathKey          = "devicePath"
 	waitTimeout            = 300
 	cloneReadinessTimeout  = 900
@@ -29,11 +28,11 @@ const (
 
 	// VolumeTags is a comma seperated string used to pass information to the linode APIs to tag the
 	// created volumes
-	VolumeTags = driverName + "/volumeTags"
+	VolumeTags = Name + "/volumeTags"
 
 	// PublishInfoVolumeName is used to pass the volume name from
 	// `ControllerPublishVolume` to `NodeStageVolume or `NodePublishVolume`
-	PublishInfoVolumeName = driverName + "/volume-name"
+	PublishInfoVolumeName = Name + "/volume-name"
 
 	VolumeLifecycleNodeStageVolume     VolumeLifecycle = "NodeStageVolume"
 	VolumeLifecycleNodePublishVolume   VolumeLifecycle = "NodePublishVolume"

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -30,6 +30,11 @@ import (
 	"k8s.io/utils/mount"
 )
 
+// Name is the name of the driver provided by this package.
+// It is also used as the name of the socket file used for container
+// orchestrator and driver communications.
+const Name = "linodebs.csi.linode.com"
+
 type LinodeDriver struct {
 	name          string
 	vendorVersion string

--- a/internal/driver/luks.go
+++ b/internal/driver/luks.go
@@ -45,15 +45,15 @@ type LuksContext struct {
 const (
 	// LuksEncryptedAttribute is used to pass the information if the volume should be
 	// encrypted with luks to `NodeStageVolume`
-	LuksEncryptedAttribute = driverName + "/luks-encrypted"
+	LuksEncryptedAttribute = Name + "/luks-encrypted"
 
 	// LuksCipherAttribute is used to pass the information about the luks encryption
 	// cipher to `NodeStageVolume`
-	LuksCipherAttribute = driverName + "/luks-cipher"
+	LuksCipherAttribute = Name + "/luks-cipher"
 
 	// LuksKeySizeAttribute is used to pass the information about the luks key size
 	// to `NodeStageVolume`
-	LuksKeySizeAttribute = driverName + "/luks-key-size"
+	LuksKeySizeAttribute = Name + "/luks-key-size"
 
 	// LuksKeyAttribute is the key of the luks key used in the map of secrets passed from the CO
 	LuksKeyAttribute = "luksKey"

--- a/main.go
+++ b/main.go
@@ -29,8 +29,6 @@ import (
 	mountmanager "github.com/linode/linode-blockstorage-csi-driver/pkg/mount-manager"
 )
 
-const driverName = "linodebs.csi.linode.com"
-
 var vendorVersion string // set by the linker
 
 type configuration struct {
@@ -113,7 +111,7 @@ func handle() error {
 		mounter,
 		deviceUtils,
 		metadata,
-		driverName,
+		driver.Name,
 		vendorVersion,
 		cfg.volumeLabelPrefix,
 	); err != nil {


### PR DESCRIPTION
The driver's name was currently being stored in an unexported const: driverName. This change renames that const symbol to "Name", which results in it being exported from the package.

The driver name was also being redefined in main.go. By exporting the internal/driver.Name const, it lets us use it from main.go.

