### PR TITLE
[fix] Address the errors we are seeing for NodeExpandVolume() in CSI-Sanity test

### DIFF
--- a/internal/driver/errors.go
+++ b/internal/driver/errors.go
@@ -15,6 +15,7 @@ var (
 	errVolumeInUse          = status.Error(codes.FailedPrecondition, "volume is in use")
 	errNoVolumeCapability   = status.Error(codes.InvalidArgument, "no volume capability set")
 	errNoVolumeID           = status.Error(codes.InvalidArgument, "volume id is not set")
+	errNoVolumePath         = status.Error(codes.InvalidArgument, "volume path is not set")
 	errNoStagingTargetPath  = status.Error(codes.InvalidArgument, "staging target path is not set")
 
 	// errNilInstance is a general-purpose error used to indicate a nil

--- a/internal/driver/nodeserver.go
+++ b/internal/driver/nodeserver.go
@@ -284,7 +284,7 @@ func (ns *LinodeNodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeE
 	}
 
 	// Check linode to see if a give volume exists by volume ID
-	// Make call to linode api using the lindoe api client
+	// Make call to linode api using the linode api client
 	LinodeVolumeKey, err := common.ParseLinodeVolumeKey(req.GetVolumeId())
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "Error parsing linode volume key: %v", err)

--- a/internal/driver/nodeserver.go
+++ b/internal/driver/nodeserver.go
@@ -279,8 +279,7 @@ func (ns *LinodeNodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeE
 	klog.V(4).Infof("NodeExpandVolume called with req: %#v", req)
 
 	// Validate req (NodeExpandVolumeRequest)
-	err := validateNodeExpandVolumeRequest(req)
-	if err != nil {
+	if err := validateNodeExpandVolumeRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -294,9 +293,7 @@ func (ns *LinodeNodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeE
 	if err != nil {
 		return nil, errInternal("marshal json filter: %v", err)
 	}
-	_, err = ns.CloudProvider.ListVolumes(ctx, linodego.NewListOptions(0, string(jsonFilter)))
-	if err != nil {
-		fmt.Printf("list volumes: %v\n", err)
+	if _, err = ns.CloudProvider.ListVolumes(ctx, linodego.NewListOptions(0, string(jsonFilter))); err != nil {
 		return nil, status.Errorf(codes.NotFound, "list volumes: %v", err)
 	}
 

--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -102,6 +102,18 @@ func validateNodeUnstageVolumeRequest(req *csi.NodeUnstageVolumeRequest) error {
 
 }
 
+// validateNodeExpandVolumeRequest validates the node expand volume request.
+// It checks the volume ID and volume path in the provided request.
+func validateNodeExpandVolumeRequest(req *csi.NodeExpandVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return errNoVolumeID
+	}
+	if req.GetVolumePath() == "" {
+		return errNoVolumePath
+	}
+	return nil
+}
+
 // getFSTypeAndMountOptions retrieves the file system type and mount options from the given volume capability.
 // If the capability is not set, the default file system type and empty mount options will be returned.
 func getFSTypeAndMountOptions(volumeCapability *csi.VolumeCapability) (string, []string) {

--- a/internal/driver/nodeserver_helpers_test.go
+++ b/internal/driver/nodeserver_helpers_test.go
@@ -922,3 +922,43 @@ func TestLinodeNodeServer_closeLuksMountSources(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateNodeExpandVolumeRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req *csi.NodeExpandVolumeRequest
+		wantErr bool
+	}{
+		{
+			name: "Valid request",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:          "vol-123",
+				VolumePath: "/mnt/staging",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing volume ID",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:          "",
+				VolumePath: "/mnt/staging",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing staging target path",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:          "vol-123",
+				VolumePath: "",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateNodeExpandVolumeRequest(tt.req); (err != nil) != tt.wantErr {
+				t.Errorf("validateNodeExpandVolumeRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The cases being addressed here from csi-sanity tests:
- Node Service NodeExpandVolume should fail when no volume id is provided
- Node Service NodeExpandVolume should fail when no volume path is provided
- Node Service NodeExpandVolume should fail when volume is not found
- Node Service NodeExpandVolume should work if node-expand is called after node-publish

**NOTE:** This PR is not for implementing the `NodeExpandVolume()`. That method is in the roadmap for future PRs. This is just meant for address errors related to validation of the request object.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

