### PR TITLE
[Fixes] - Addressing test cases we found running sanity tests for Controller Plugin

### DIFF
--- a/hack/csi-sanity.sh
+++ b/hack/csi-sanity.sh
@@ -10,9 +10,8 @@ DELETE_DIRECTORY="./tests/csi-sanity/rmdir_in_pod.sh"
 # Define the list of tests to skip as an array
 SKIP_TESTS=(
   "WithCapacity"
-  "should fail when requesting to create a volume with already existing name and different capacity"
-  "should fail when the volume source volume is not found"
-  "should fail when the volume is already published but is incompatible"
+  # Need to skip it because we do not support volume snapshots
+  "should fail when the volume source volume is not found" 
 )
 
 # Join the array into a single string with '|' as the separator

--- a/internal/driver/capabilities.go
+++ b/internal/driver/capabilities.go
@@ -8,7 +8,6 @@ func ControllerServiceCapabilities() []*csi.ControllerServiceCapability {
 	capabilities := []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
-		csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,

--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -115,9 +115,13 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return &csi.CreateVolumeResponse{}, errNoVolumeName
 	}
 
+	// validate volume capabilities
 	volCapabilities := req.GetVolumeCapabilities()
 	if len(volCapabilities) == 0 {
 		return &csi.CreateVolumeResponse{}, errNoVolumeCapabilities
+	}
+	if !validVolumeCapabilities(volCapabilities) {
+		return &csi.CreateVolumeResponse{}, errInvalidVolumeCapability(volCapabilities)
 	}
 
 	capRange := req.GetCapacityRange()
@@ -285,9 +289,8 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	if cap == nil {
 		return &csi.ControllerPublishVolumeResponse{}, errNoVolumeCapability
 	}
-
-	if vc := req.GetVolumeCapability(); !validVolumeCapabilities([]*csi.VolumeCapability{vc}) {
-		return &csi.ControllerPublishVolumeResponse{}, errInvalidVolumeCapability(vc)
+	if !validVolumeCapabilities([]*csi.VolumeCapability{cap}) {
+		return &csi.ControllerPublishVolumeResponse{}, errInvalidVolumeCapability([]*csi.VolumeCapability{cap})
 	}
 
 	klog.V(4).Infof("controller publish volume called with %v", map[string]interface{}{

--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -180,21 +180,11 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return &csi.CreateVolumeResponse{}, err
 	}
 
-	// Attempt to resize the volume if necessary
+	// If the existing volume size differs from the requested size, we throw an error.
 	if vol.Size != targetSizeGB {
 		if sourceVolumeInfo == nil {
-			// throw and error with grpc code already exits
+			// error with grpc code already exits
 			return nil, errAlreadyExists("volume %d already exists of size %d", vol.ID, vol.Size)
-		}
-		// Not sure if we need to resize here?
-		klog.V(4).Infoln("resizing volume", map[string]interface{}{
-			"volume_id": vol.ID,
-			"old_size":  vol.Size,
-			"new_size":  targetSizeGB,
-		})
-
-		if err := cs.client.ResizeVolume(ctx, vol.ID, targetSizeGB); err != nil {
-			return &csi.CreateVolumeResponse{}, errInternal("resize cloned volume (%d): %v", targetSizeGB, err)
 		}
 	}
 

--- a/internal/driver/errors.go
+++ b/internal/driver/errors.go
@@ -82,3 +82,11 @@ func errInvalidVolumeCapability(capability *csi.VolumeCapability) error {
 func errInternal(format string, args ...any) error {
 	return status.Errorf(codes.Internal, format, args...)
 }
+
+// errAlreadyExists returns a gRPC error for an already existing resource.
+//
+// Parameters: format (string), args (...any)
+// Returns: error
+func errAlreadyExists(format string, args ...any) error {
+	return status.Errorf(codes.AlreadyExists, format, args...)
+}

--- a/internal/driver/errors.go
+++ b/internal/driver/errors.go
@@ -73,8 +73,8 @@ func errVolumeNotFound(volumeID int) error {
 	return status.Errorf(codes.NotFound, "volume not found: %d", volumeID)
 }
 
-func errInvalidVolumeCapability(capability *csi.VolumeCapability) error {
-	return status.Errorf(codes.InvalidArgument, "invalid volume capability: %s", capability)
+func errInvalidVolumeCapability(capability []*csi.VolumeCapability) error {
+	return status.Errorf(codes.InvalidArgument, "invalid volume capability: %v", capability)
 }
 
 // errInternal is a convenience function to return a gRPC error with an


### PR DESCRIPTION
The test cases to address:
- "should fail when requesting to create a volume with already existing name and different capacity"
     - We now throwing error with grpc code AlreadyExist when existing vol capacity differs from requested one.
- "should fail when the volume is already published but is incompatible"
     - Remove the capability for READONLY volumes since we do not support creating read only volumes on the cloud provider side at the moment. If needed, we could provide readonly capability on the Node Plugin side in future.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

