### PR TITLE
add xfsprogs to add mkfs.xfs binary to csi-linode-node pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ LABEL description="Linode CSI Driver"
 
 COPY --from=builder /bin/linode-blockstorage-csi-driver /linode
 
-RUN apk add --no-cache e2fsprogs findmnt blkid cryptsetup
+RUN apk add --no-cache e2fsprogs findmnt blkid cryptsetup xfsprogs
 
 ENTRYPOINT ["/linode"]

--- a/e2e/test/pod-pvc-create-xfs-filesystem/assert-csi-driver-resources.yaml
+++ b/e2e/test/pod-pvc-create-xfs-filesystem/assert-csi-driver-resources.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-linode-node
+  namespace: kube-system
+status:
+  numberAvailable: ($nodes)
+  numberReady: ($nodes)
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: csi-linode-controller
+  namespace: kube-system
+status:
+  availableReplicas: 1
+  readyReplicas: 1

--- a/e2e/test/pod-pvc-create-xfs-filesystem/assert-pvc-pod.yaml
+++ b/e2e/test/pod-pvc-create-xfs-filesystem/assert-pvc-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-xfs
+status:
+  containerStatuses:
+  - name: e2e-pod-xfs
+    ready: true
+    started: true
+  phase: Running
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xfs
+status:
+  capacity:
+    storage: 10Gi
+  phase: Bound

--- a/e2e/test/pod-pvc-create-xfs-filesystem/chainsaw-test.yaml
+++ b/e2e/test/pod-pvc-create-xfs-filesystem/chainsaw-test.yaml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: pod-pvc-create-xfs-filesystem
+spec:
+  bindings:
+    - name: nodes
+      # number of nodes in cluster
+      value: ((env('WORKER_NODES') | to_number(@)) + (env('CONTROLPLANE_NODES') | to_number(@)))
+  steps:
+    - name: Check if CSI Driver is deployed
+      try:
+        - assert:
+            file: assert-csi-driver-resources.yaml
+    - name: Create PVC and Pod
+      try:
+        - apply:
+            file: create-pvc-pod.yaml
+      catch:
+        - describe:
+            apiVersion: v1
+            kind: Pod
+        - describe:
+            apiVersion: v1
+            kind: PersistentVolumeClaim
+    - name: Check if Pod is ready and Volume is mounted
+      try:
+        - assert:
+            file: assert-pvc-pod.yaml
+      catch:
+        - describe:
+            apiVersion: v1
+            kind: PersistentVolumeClaim
+        - describe:
+            apiVersion: v1
+            kind: Pod
+    - name: Check if volume is create and size is 10Gi
+      try:
+        - script:
+            env:
+              - name: TARGET_API
+                value: api.linode.com
+              - name: TARGET_API_VERSION
+                value: v4beta
+              - name: URI
+                value: volumes
+              - name: FILTER
+                value: (to_string({"tags":($namespace)}))
+            content: |
+              set -e
+              curl -s \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                -H "X-Filter: $FILTER" \
+                -H "Content-Type: application/json" \
+                "https://api.linode.com/v4beta/volumes"
+            check:
+              ($error): ~
+              (json_parse($stdout)):
+                results: 1
+                data:
+                  - size: 10
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: PersistentVolume
+              spec:
+                capacity:
+                  storage: 10Gi
+    - name: Check filesystem type to be xfs filesystem for mounted volume
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              kubectl exec -n $NAMESPACE e2e-pod-xfs -- sh -c "mount | grep data"
+            check:
+              ($error): ~
+              (contains($stdout, 'on /data type xfs')): true
+    - name: Delete the Pod
+      try:
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Pod
+    - name: Check if the volume is detached on Node resource and in Linode (using API)
+      try:
+        - script:
+            env:
+              - name: FILTER
+                value: (to_string({"tags":($namespace)}))
+            content: |
+              ../check-volume-detached.sh $FILTER
+            check:
+              ($error): ~
+              (contains($stdout, 'Volume was successfully detached')): true
+              (contains($stdout, 'Volume detached in Linode')): true
+    - name: Delete PVC
+      try:
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+    - name: Check if the Volume was deleted
+      try:
+        - script:
+            env:
+              - name: FILTER
+                value: (to_string({"tags":($namespace)}))
+            content: |
+              ../check-volume-deleted.sh $FILTER
+            check:
+              ($error): ~
+              (contains($stdout, 'Volume deleted in Linode')): true

--- a/e2e/test/pod-pvc-create-xfs-filesystem/create-pvc-pod.yaml
+++ b/e2e/test/pod-pvc-create-xfs-filesystem/create-pvc-pod.yaml
@@ -1,0 +1,45 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: (join('-', ['linode-block-storage', $namespace]))
+provisioner: linodebs.csi.linode.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+    linodebs.csi.linode.com/volumeTags: (to_string($namespace))
+    fstype: xfs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xfs
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: (join('-', ['linode-block-storage', $namespace]))
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-xfs
+spec:
+  containers:
+  - name: e2e-pod-xfs
+    image: ubuntu
+    command: ["/bin/sh"]
+    args: ["-xc", "/bin/dd if=/dev/block of=/dev/null bs=1K count=10; /bin/sleep 1000000"]
+    volumeMounts:
+    - name: csi-volume
+      mountPath: "/data"
+  tolerations:
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Exists"
+    effect: "NoSchedule"
+  volumes:
+  - name: csi-volume
+    persistentVolumeClaim:
+      claimName: pvc-xfs


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

There was a long standing request to support xfs filesystem within PVCs provisioned by linode-csi-driver: https://www.linode.com/community/questions/20316/create-a-persistentvolume-on-lke-with-a-different-fstype

One of the dependencies were resolved recently which added volumemode=block support: https://github.com/linode/linode-blockstorage-csi-driver/pull/126

However, when provisioning pvcs with fstype as xfs, it was still failing as the mkfs.xfs binary was missing from the pods.

This PR adds this binary so that one can provision PVCs with filesystem of type xfs. Here is the output from csi-linode-plugin container of csi-linode-node pod before and after adding the binary.

Before:
```
/ # ls /sbin/mkfs*
/sbin/mkfs.ext2  /sbin/mkfs.ext3  /sbin/mkfs.ext4  /sbin/mkfs.vfat
```

After:
```
/ # ls /sbin/mkfs*
/sbin/mkfs.ext2  /sbin/mkfs.ext3  /sbin/mkfs.ext4  /sbin/mkfs.vfat  /sbin/mkfs.xfs
```

Here is a sample yaml one can use to test it out with this branch:

```
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: linode-block-storage-retain-xfs
parameters:
    fstype: xfs
provisioner: linodebs.csi.linode.com
reclaimPolicy: Retain
volumeBindingMode: Immediate
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: csi-example-pod
spec:
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app: csi-example-pod
  replicas: 1
  template:
    metadata:
      labels:
        app: csi-example-pod
    spec:
      containers:
      - name: csi-example-pod
        image: busybox
        volumeMounts:
        - mountPath: "/data"
          name: csi-example-volume
        command: [ "sleep", "1000000" ]
      volumes:
      - name: csi-example-volume
        persistentVolumeClaim:
          claimName: csi-example-pvc
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-example-pvc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: linode-block-storage-retain-xfs
```
### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

