### PR TITLE
[Fix] Re-enable Readonly since we support mounting the volume in that mode on the Node Plugin side

### DIFF
--- a/hack/csi-sanity.sh
+++ b/hack/csi-sanity.sh
@@ -12,6 +12,9 @@ SKIP_TESTS=(
   "WithCapacity"
   # Need to skip it because we do not support volume snapshots
   "should fail when the volume source volume is not found" 
+  # This case fails because we currently do not support read only volume creation on the linode side
+  # but we are supporting it in the CSI driver by mounting the volume as read only
+  "should fail when the volume is already published but is incompatible"
 )
 
 # Join the array into a single string with '|' as the separator

--- a/internal/driver/capabilities.go
+++ b/internal/driver/capabilities.go
@@ -6,6 +6,7 @@ import "github.com/container-storage-interface/spec/lib/go/csi"
 // this driver's controller service.
 func ControllerServiceCapabilities() []*csi.ControllerServiceCapability {
 	capabilities := []csi.ControllerServiceCapability_RPC_Type{
+		csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,


### PR DESCRIPTION
**REASON:** In my previous PR, I removed the functionality for read only volumes because according to the CSI-Driver spec we are suppose to create a read only volume on the Linode side. But Linode currently does not support that. To get around that, we are currently mounting the volume as read-only on the Node plugin side when we publish the volume. To avoid any issues with customer (who might be using it currently), I'm re-enabling it and just skipping the associated csi-sanity test case.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

