### PR TITLE
test ext2, ext3, ext4, xfs as supported filesystem type

### DIFF
--- a/tests/upstream-e2e/run-tests.sh
+++ b/tests/upstream-e2e/run-tests.sh
@@ -13,20 +13,19 @@ curl -L ${URL} -o ${OUT_TAR}
 tar xzvf ${OUT_TAR} -C ${OUT_DIR}
 
 # Run k8s e2e tests for storage driver
-./${OUT_DIR}/kubernetes/test/bin/e2e.test \
-    -ginkgo.v \
-    -ginkgo.focus='External.Storage' \
-    --ginkgo.skip='disruptive' \
-    --ginkgo.skip='ephemeral' \
-    --ginkgo.skip='volume-expand' \
-    --ginkgo.skip='multiVolume' \
-    --ginkgo.skip='snapshottable' \
-    --ginkgo.skip='snapshottable-stress' \
-    --ginkgo.skip='\[Feature:VolumeSnapshotDataSource\]' \
-    --ginkgo.skip='\[Feature:Windows\]' \
-    --ginkgo.flake-attempts=3 \
-    --ginkgo.timeout=2h \
-    -storage.testdriver=tests/upstream-e2e/test-driver.yaml
+./${OUT_DIR}/kubernetes/test/bin/e2e.test                   `# runs kubernetes e2e tests` \
+    -ginkgo.v                                               `# enables verbose output` \
+    -ginkgo.focus='External.Storage'                        `# onl run external storage tests` \
+    --ginkgo.skip='\[Disruptive\]'                          `# skip disruptive tests as they need ssh access to nodes` \
+    --ginkgo.skip='volume-expand'                           `# skip volume-expand as its done manually for now` \
+    --ginkgo.skip='multiVolume'                             `# skip multi volume as some e2e tests were failing` \
+    --ginkgo.skip='snapshottable'                           `# skip as we don't support snapshots` \
+    --ginkgo.skip='snapshottable-stress'                    `# skip as we don't support snapshots` \
+    --ginkgo.skip='\[Feature:VolumeSnapshotDataSource\]'    `# skip as we don't support snapshots` \
+    --ginkgo.skip='\[Feature:Windows\]'                     `# skip as we don't support windows` \
+    --ginkgo.flake-attempts=3                               `# retry 3 times for flaky tests` \
+    --ginkgo.timeout=2h                                     `# tests can run for max 2 hours` \
+    -storage.testdriver=tests/upstream-e2e/test-driver.yaml `# configuration file for storage driver capabilities`
 
 # Remove downloaded files and binaries
 rm -rf ${OUT_DIR}

--- a/tests/upstream-e2e/test-driver.yaml
+++ b/tests/upstream-e2e/test-driver.yaml
@@ -2,6 +2,7 @@ StorageClass:
   FromName: true
 DriverInfo:
   Name: linodebs.csi.linode.com
+  SupportedFsType: {"ext2", "ext3", "ext4", "xfs"}
   Capabilities:
     block: true
     controllerExpansion: false
@@ -10,5 +11,6 @@ DriverInfo:
     persistence: true
     pvcDataSource: true
     snapshotDataSource: false
-InlineVolumes:
-- Attributes: {}
+  SupportedSizeRange:
+    Min: 10G
+    Max: 10T


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

This PR now tells upstream e2e tests to test ext2, ext3, ext4, xfs as well. This increases our total covered specs from 29 to 45. Here is sample output run:
Before:
```
------------------------------
SSS
------------------------------
[SynchronizedAfterSuite] 
test/e2e/e2e.go:88
  Aug 23 15:21:12.453: INFO: Running AfterSuite actions on node 1
[SynchronizedAfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Kubernetes e2e suite report
test/e2e/e2e_test.go:161
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 29 of 7692 Specs in 2428.116 seconds
SUCCESS! -- 29 Passed | 0 Failed | 1 Flaked | 0 Pending | 7663 Skipped
PASS
```
After:
```
test/e2e/e2e.go:88
  Aug 27 16:22:15.516: INFO: Running AfterSuite actions on node 1
[SynchronizedAfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Kubernetes e2e suite report
test/e2e/e2e_test.go:161
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 45 of 7692 Specs in 4566.865 seconds
SUCCESS! -- 45 Passed | 0 Failed | 2 Flaked | 0 Pending | 7647 Skipped
PASS
```
### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

