### PR TITLE
[Cleanup] Replace Status.Error() with helper func() defined in errors.go

### DIFF
--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -24,8 +24,6 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/common"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/mount-manager"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
@@ -155,14 +153,12 @@ func (ns *LinodeNodeServer) findDevicePath(key common.LinodeVolumeKey, partition
 	// Verify the device path by checking if any of the paths exist.
 	devicePath, err := ns.DeviceUtils.VerifyDevicePath(devicePaths)
 	if err != nil {
-		return "", status.Error(codes.Internal, fmt.Sprintf("Error verifying Linode Volume (%q) is attached: %v",
-			key.GetVolumeLabel(), err))
+		return "", errInternal("Error verifying Linode Volume (%q) is attached: %v", key.GetVolumeLabel(), err)
 	}
 
 	// If no device path is found, return an error.
 	if devicePath == "" {
-		return "", status.Error(codes.Internal, fmt.Sprintf("Unable to find device path out of attempted paths: %v",
-			devicePaths))
+		return "", errInternal("Unable to find device path out of attempted paths: %v", devicePaths)
 	}
 
 	// If a device path is found, return it.
@@ -179,11 +175,11 @@ func (ns *LinodeNodeServer) ensureMountPoint(path string, fs mountmanager.FileSy
 		// Checking IsNotExist returns true. If true, it mean we need to create directory at the target path.
 		if fs.IsNotExist(err) {
 			if err := fs.MkdirAll(path, rwPermission); err != nil {
-				return true, status.Error(codes.Internal, fmt.Sprintf("Failed to create directory (%q): %v", path, err))
+				return true, errInternal("Failed to create directory (%q): %v", path, err)
 			}
 		} else {
 			// If the error is unknown, return an error.
-			return true, status.Error(codes.Internal, fmt.Sprintf("Unknown error when checking mount point (%q): %v", path, err))
+			return true, errInternal("Unknown error when checking mount point (%q): %v", path, err)
 		}
 	}
 	return notMnt, nil
@@ -204,14 +200,14 @@ func (ns *LinodeNodeServer) nodePublishVolumeBlock(req *csi.NodePublishVolumeReq
 	// Get the device path from the request
 	devicePath := req.PublishContext["devicePath"]
 	if devicePath == "" {
-		return nil, status.Error(codes.Internal, "devicePath cannot be found")
+		return nil, errInternal("devicePath cannot be found")
 	}
 
 	// Create directory at the directory level of given path
 	klog.V(5).Infof("NodePublishVolume[block]: making targetPathDir %s", targetPathDir)
 	if err := fs.MkdirAll(targetPathDir, rwPermission); err != nil {
 		klog.Errorf("mkdir failed on disk %s (%v)", targetPathDir, err)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create directory (%q): %v", targetPathDir, err))
+		return nil, errInternal("Failed to create directory %q: %v", targetPathDir, err)
 	}
 
 	// Make file to bind mount block device to file
@@ -219,18 +215,18 @@ func (ns *LinodeNodeServer) nodePublishVolumeBlock(req *csi.NodePublishVolumeReq
 	file, err := fs.OpenFile(targetPath, os.O_CREATE, ownerGroupReadWritePermissions)
 	if err != nil {
 		if removeErr := fs.Remove(targetPath); removeErr != nil {
-			return nil, status.Errorf(codes.Internal, "Failed remove mount target %s: %v", targetPath, err)
+			return nil, errInternal("Failed remove mount target %q: %v", targetPath, err)
 		}
-		return nil, status.Errorf(codes.Internal, "Failed to create file %s: %v", targetPath, err)
+		return nil, errInternal("Failed to create file %s: %v", targetPath, err)
 	}
 	file.Close()
 
 	// Mount the volume
 	if err := ns.Mounter.Mount(devicePath, targetPath, "", mountOptions); err != nil {
 		if removeErr := fs.Remove(targetPath); removeErr != nil {
-			return nil, status.Errorf(codes.Internal, "Failed remove mount target %q: %v", targetPath, err)
+			return nil, errInternal("Failed remove mount target %q: %v", targetPath, err)
 		}
-		return nil, status.Errorf(codes.Internal, "Could not mount %q at %q: %v", devicePath, targetPath, err)
+		return nil, errInternal("Could not mount %q at %q: %v", devicePath, targetPath, err)
 	}	
 
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -263,9 +259,8 @@ func (ns *LinodeNodeServer) mountVolume(devicePath string, req *csi.NodeStageVol
 	// Format and mount the drive
 	klog.V(4).Info("formatting and mounting the drive")
 	if err := ns.Mounter.FormatAndMount(fmtAndMountSource, stagingTargetPath, fsType, mountOptions); err != nil {
-		return status.Error(codes.Internal,
-			fmt.Sprintf("Failed to format and mount device from (%q) to (%q) with fstype (%q) and options (%q): %v",
-				devicePath, stagingTargetPath, fsType, mountOptions, err))
+		return errInternal("Failed to format and mount device from (%q) to (%q) with fstype (%q) and options (%q): %v", 
+				devicePath, stagingTargetPath, fsType, mountOptions, err)
 	}
 
 	return nil
@@ -283,7 +278,7 @@ func (ns *LinodeNodeServer) prepareLUKSVolume(devicePath string, luksContext Luk
 	// Validate if the device is formatted with LUKS encryption or if it needs formatting.
 	formatted, err := ns.Encrypt.blkidValid(devicePath)
 	if err != nil {
-		return "", status.Error(codes.Internal, fmt.Sprintf("Failed to validate blkid (%q): %v", devicePath, err))
+		return "", errInternal("Failed to validate blkid (%q): %v", devicePath, err)
 	}
 
 	// If the device is not, format it.
@@ -292,19 +287,19 @@ func (ns *LinodeNodeServer) prepareLUKSVolume(devicePath string, luksContext Luk
 
 		// Validate the LUKS context.
 		if err := luksContext.validate(); err != nil {
-			return "", status.Error(codes.Internal, fmt.Sprintf("Failed to luks format validation (%q): %v", devicePath, err))
+			return "", errInternal("Failed to luks format validation (%q): %v", devicePath, err)
 		}
 
 		// Format the volume with LUKS encryption.
 		if err := ns.Encrypt.luksFormat(luksContext, devicePath); err != nil {
-			return "", status.Error(codes.Internal, fmt.Sprintf("Failed to luks format (%q): %v", devicePath, err))
+			return "", errInternal("Failed to luks format (%q): %v", devicePath, err)
 		}
 	}
 
 	// Prepare the LUKS volume for mounting.
 	luksSource, err := ns.Encrypt.luksPrepareMount(luksContext, devicePath)
 	if err != nil {
-		return "", status.Error(codes.Internal, fmt.Sprintf("Failed to prepare luks mount (%q): %v", devicePath, err))
+		return "", errInternal("Failed to prepare luks mount (%q): %v", devicePath, err)
 	}
 
 	return luksSource, nil
@@ -316,18 +311,18 @@ func (ns *LinodeNodeServer) prepareLUKSVolume(devicePath string, luksContext Luk
 func (ns *LinodeNodeServer) closeLuksMountSources(path string) error {
 	mountSources, err := ns.getMountSources(path)
 	if err != nil {
-		return status.Error(codes.Internal, fmt.Sprintf("closeMountSources failed to to get mount sources %s: %v", path, err))
+		return errInternal("closeMountSources failed to to get mount sources %s: %v", path, err)
 	}
 	klog.V(4).Info("closing mount sources: ", mountSources)
 	for _, source := range mountSources {
 		isLuksMapping, mappingName, err := ns.Encrypt.isLuksMapping(source)
 		if err != nil {
-			return status.Error(codes.Internal, fmt.Sprintf("closeMountSources failed determine if mount is a luks mapping %s: %v", path, err))
+			return errInternal("closeMountSources failed determine if mount is a luks mapping %s: %v", path, err)
 		}
 		if isLuksMapping {
 			klog.V(4).Infof("luksClose %s", mappingName)
 			if err := ns.Encrypt.luksClose(mappingName); err != nil {
-				return status.Error(codes.Internal, fmt.Sprintf("closeMountSources failed to close luks mount %s: %v", path, err))
+				return errInternal("closeMountSources failed to close luks mount %s: %v", path, err)
 			}
 		}
 	}

--- a/internal/driver/nodeserver_helpers_test.go
+++ b/internal/driver/nodeserver_helpers_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/linode/linode-blockstorage-csi-driver/mocks"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/common"
 	"go.uber.org/mock/gomock"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/exec"
@@ -214,7 +213,7 @@ func TestLinodeNodeServer_findDevicePath(t *testing.T) {
 				dUtils.EXPECT().VerifyDevicePath(gomock.Any()).Return("", fmt.Errorf("no volume attached"))
 			},
 			wantDevicePath: "",
-			wantErr:        status.Error(codes.Internal, "Error verifying Linode Volume (\"test\") is attached: no volume attached"),
+			wantErr:        errInternal("Error verifying Linode Volume (\"test\") is attached: no volume attached"),
 		},
 		{
 			name: "Error - Couldn't get the devicepath to linode volume",
@@ -227,7 +226,7 @@ func TestLinodeNodeServer_findDevicePath(t *testing.T) {
 				dUtils.EXPECT().VerifyDevicePath(gomock.Any()).Return("", nil)
 			},
 			wantDevicePath: "",
-			wantErr:        status.Error(codes.Internal, "Unable to find device path out of attempted paths: [some/path]"),
+			wantErr:        errInternal("Unable to find device path out of attempted paths: [some/path]"),
 		},
 		{
 			name: "Success",
@@ -312,7 +311,7 @@ func TestLinodeNodeServer_ensureMountPoint(t *testing.T) {
 				m.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want:    false,
-			wantErr: status.Error(codes.Internal, "Failed to create directory (\"/mnt/staging\"): couldn't create directory"),
+			wantErr: errInternal("Failed to create directory (/mnt/staging): couldn't create directory"),
 		},
 		{
 			name:              "Error -  mount point check fails and error is not IsNotExist",
@@ -325,7 +324,7 @@ func TestLinodeNodeServer_ensureMountPoint(t *testing.T) {
 				m.EXPECT().IsNotExist(gomock.Any()).Return(false)
 			},
 			want:    true,
-			wantErr: status.Error(codes.Internal, "Unknown error when checking mount point (\"/mnt/staging\"): some error"),
+			wantErr: errInternal("Unknown error when checking mount point (\"/mnt/staging\"): some error"),
 		},
 		{
 			name:              "Error -  Mount point didn't exist and ran into error when create a new mount point or directory",
@@ -339,7 +338,7 @@ func TestLinodeNodeServer_ensureMountPoint(t *testing.T) {
 				m.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(fmt.Errorf("couldn't create directory"))
 			},
 			want:    true,
-			wantErr: status.Error(codes.Internal, "Failed to create directory (\"/mnt/staging\"): couldn't create directory"),
+			wantErr: errInternal("Failed to create directory (\"/mnt/staging\"): couldn't create directory"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Reason: We introduced errors.go with bunch of predefined errors and funcs() a while back and we want to make sure we use it in the code base to maintain uniformity and consistent error logging

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

