### PR TITLE
[Cleanup] Refactor LinodeIdentityServer for uniformity

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -41,7 +41,7 @@ type LinodeDriver struct {
 	vendorVersion     string
 	volumeLabelPrefix string
 
-	ids *LinodeIdentityServer
+	ids *IdentityServer
 	ns  *LinodeNodeServer
 	cs  *ControllerServer
 
@@ -102,7 +102,10 @@ func (linodeDriver *LinodeDriver) SetupLinodeDriver(
 	linodeDriver.volumeLabelPrefix = volumeLabelPrefix
 
 	// Set up RPC Servers
-	linodeDriver.ids = NewIdentityServer(linodeDriver)
+	linodeDriver.ids, err = NewIdentityServer(linodeDriver)
+	if err != nil {
+		return fmt.Errorf("new identity server: %w", err)
+	}
 	linodeDriver.ns = NewNodeServer(linodeDriver, mounter, deviceUtils, linodeClient, metadata, encrypt)
 
 	cs, err := NewControllerServer(linodeDriver, linodeClient, metadata)
@@ -126,12 +129,6 @@ func (linodeDriver *LinodeDriver) ValidateControllerServiceRequest(c csi.Control
 	}
 
 	return status.Error(codes.InvalidArgument, "Invalid controller service request")
-}
-
-func NewIdentityServer(linodeDriver *LinodeDriver) *LinodeIdentityServer {
-	return &LinodeIdentityServer{
-		Driver: linodeDriver,
-	}
 }
 
 func NewNodeServer(linodeDriver *LinodeDriver, mounter *mount.SafeFormatAndMount, deviceUtils mountmanager.DeviceUtils, cloudProvider linodeclient.LinodeClient, metadata Metadata, encrypt Encryption) *LinodeNodeServer {

--- a/internal/driver/identityserver_test.go
+++ b/internal/driver/identityserver_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewIdentityServer(t *testing.T) {
+	type args struct {
+		linodeDriver *LinodeDriver
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *IdentityServer
+		wantErr bool
+	}{
+		{
+			name: "Success",
+			args: args{
+				linodeDriver: &LinodeDriver{},
+			},
+			want: &IdentityServer{
+				driver: &LinodeDriver{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Nil linodeDriver",
+			args: args{
+				linodeDriver: nil,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewIdentityServer(tt.args.linodeDriver)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewIdentityServer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewIdentityServer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR renames LinodeIdentityServer to IdentityServer and adjusts its fields to align with the naming conventions used in ControllerServer. Additionally, NewIdentityServer() has been moved from driver.go to identityserver.go to improve code organization.

These changes enhance code uniformity and maintainability across the codebase

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

