### PR TITLE
Improve error handling for csi-sanity and fix for failing sanity tests

### DIFF
--- a/internal/driver/errors.go
+++ b/internal/driver/errors.go
@@ -84,6 +84,12 @@ func errInternal(format string, args ...any) error {
 	return status.Errorf(codes.Internal, format, args...)
 }
 
+// errNotFound returns a gRPC error with a NOT_FOUND status code.
+// It formats the error message using the provided format and arguments.
+func errNotFound(format string, args ...any) error {
+	return status.Errorf(codes.NotFound, format, args...)
+}
+
 // errAlreadyExists returns a gRPC error for an already existing resource.
 //
 // Parameters: format (string), args (...any)

--- a/internal/driver/nodeserver.go
+++ b/internal/driver/nodeserver.go
@@ -287,7 +287,9 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	LinodeVolumeKey, err := linodevolumes.ParseLinodeVolumeKey(volumeID)
 	log.V(4).Info("Processed LinodeVolumeKey", "LinodeVolumeKey", LinodeVolumeKey)
 	if err != nil {
-		return nil, errVolumeNotFound(LinodeVolumeKey.VolumeID)
+		// Node volume expansion is not supported yet. To meet the spec, we need to implement this.
+		// For now, we'll return a not found error.
+		return nil, errNotFound("volume not found: %v", err)
 	}
 	jsonFilter, err := json.Marshal(map[string]string{"label": LinodeVolumeKey.Label})
 	if err != nil {

--- a/internal/driver/nodeserver.go
+++ b/internal/driver/nodeserver.go
@@ -285,6 +285,7 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	// Check linode to see if a give volume exists by volume ID
 	// Make call to linode api using the linode api client
 	LinodeVolumeKey, err := linodevolumes.ParseLinodeVolumeKey(volumeID)
+	log.V(4).Info("Processed LinodeVolumeKey", "LinodeVolumeKey", LinodeVolumeKey)
 	if err != nil {
 		return nil, errVolumeNotFound(LinodeVolumeKey.VolumeID)
 	}

--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -406,11 +406,6 @@ func (ns *NodeServer) getMountSource(ctx context.Context, input string) (string,
 		return "", fmt.Errorf("invalid input format: %s", input)
 	}
 
-	// Check if the second part starts with "pvc"
-	if !strings.HasPrefix(parts[1], "pvc") {
-		return "", fmt.Errorf("invalid input: second part must start with 'pvc'")
-	}
-
 	result := parts[1]
 	log.V(4).Info("Exiting getMountSources", "result", result)
 	return result, nil

--- a/internal/driver/nodeserver_helpers_test.go
+++ b/internal/driver/nodeserver_helpers_test.go
@@ -853,11 +853,6 @@ func TestNodeServer_closeLuksMountSource(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Error - Invalid volume ID",
-			volumeID:    "3232-test1234",
-			wantErr: true,
-		},
-		{
 			name: "Error - unable to find cryptsetup",
 			expectExecCalls: func(m *mocks.MockExecutor, c *mocks.MockCommand) {
 				m.EXPECT().LookPath(gomock.Any()).Return("", osexec.ErrNotFound)

--- a/tests/csi-sanity/run-tests.sh
+++ b/tests/csi-sanity/run-tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euf -o pipefail
 
 # Define the CSI endpoint for the sanity tests
 CSI_ENDPOINT="dns:///127.0.0.1:10000"


### PR DESCRIPTION
Due to previous change with how we now handle getting mount source to close luks volume, it introduced test failures in the csi-sanity tests which went unnoticed. This PR fixes the issue and improved the error propagation from the csi-sanity script.

Example error from CSI-Sanity tests:

`<*errors.errorString | 0xc000404230>{
              s: "NodeUnstageVolume for volume ID 6076319-sanitynodefull17047E444ED144616 failed: rpc error: code = Internal desc = Failed to close the luks volume 6076319-sanitynodefull17047E444ED144616: rpc error: code = Internal desc = closeLuksMountSource failed to get mount source 6076319-sanitynodefull17047E444ED144616: invalid input: second part must start with 'pvc'",
          },`


### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

