### PR TITLE
[Cleanup] Update the REV var to use current branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PLATFORM           ?= linux/amd64
 REGISTRY_NAME      ?= index.docker.io
 IMAGE_NAME         ?= linode/linode-blockstorage-csi-driver
-REV                := $(shell git describe --long --tags --dirty 2> /dev/null || echo "dev")
+REV                := $(shell git branch --show-current 2> /dev/null || echo "dev")
 IMAGE_VERSION      ?= $(REV)
 IMAGE_TAG          ?= $(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 GOLANGCI_LINT_IMG  := golangci/golangci-lint:v1.59-alpine


### PR DESCRIPTION
When running `devbox run capl-cluster`, the image tag for CSI-driver (if not specified) should be the current branch name. This PR updates that so when we deploy capl-cluster for local testing, by default we will use current branch name as the image tag to deploy CSI driver on capl-cluster

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

