### PR TITLE
bump alpine version back to 3.18.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go mod download
 
 RUN CGO_ENABLED=1 go build -a -ldflags '-X main.vendorVersion='${REV}'' -o /bin/linode-blockstorage-csi-driver /linode
 
-FROM alpine:3.20.3
+FROM alpine:3.18.4
 LABEL maintainers="Linode"
 LABEL description="Linode CSI Driver"
 


### PR DESCRIPTION
After dependabot version update for alpine version 3.20.x, we were seeing xfs mounting failures. This is a known issue with alpine version after 3.19. We need to test some solutions before we can bump up the version.

Solution for now is to revert back to 3.18.4 until we find a robust solution for the new version

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

