### PR TITLE
Fix code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"math"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/linode/linodego"
@@ -312,6 +313,11 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 		if errParse != nil {
 			return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted,
 				"invalid starting token: %q", startingToken)
+		}
+
+		if startingPage < math.MinInt || startingPage > math.MaxInt {
+			return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted,
+				"starting token out of bounds: %q", startingToken)
 		}
 
 		listOpts.Page = int(startingPage)


### PR DESCRIPTION
Fixes [https://github.com/linode/linode-blockstorage-csi-driver/security/code-scanning/2](https://github.com/linode/linode-blockstorage-csi-driver/security/code-scanning/2)

To fix the problem, we need to ensure that the conversion from `int64` to `int` is safe by checking that the value of `startingPage` is within the bounds of the `int` type. This can be done by adding a bounds check before the conversion. If the value is out of bounds, we should handle the error appropriately.

1. Add bounds checking for `startingPage` before converting it to `int`.
2. Use the constants `math.MaxInt` and `math.MinInt` to check the bounds.
3. If `startingPage` is out of bounds, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
