### PR TITLE
feat: make the test cluster creation process robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ create-capl-cluster:
 	# Create a CAPL cluster without CSI driver and wait for it to be ready
 	kubectl apply -f capl-cluster-manifests.yaml
 	kubectl wait --for=condition=ControlPlaneReady cluster/$(CLUSTER_NAME) --timeout=600s || (kubectl get cluster -o yaml; kubectl get linodecluster -o yaml; kubectl get linodemachines -o yaml)
-	kubectl wait --for=condition=Ready=true machines --all --timeout=900s
+	kubectl wait --for=condition=NodeHealthy=true machines --all --timeout=900s
 	clusterctl get kubeconfig $(CLUSTER_NAME) > test-cluster-kubeconfig.yaml
 	KUBECONFIG=test-cluster-kubeconfig.yaml kubectl wait --for=condition=Ready nodes --all --timeout=600s
 	cat tests/e2e/setup/linode-secret.yaml | envsubst | KUBECONFIG=test-cluster-kubeconfig.yaml kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ CAPI_VERSION         ?= "v1.6.3"
 HELM_VERSION         ?= "v0.2.1"
 CAPL_VERSION         ?= "v0.6.4"
 CONTROLPLANE_NODES   ?= 1
-WORKER_NODES         ?= 0
+WORKER_NODES         ?= 1
 
 .PHONY: build
 build:
@@ -104,8 +104,10 @@ generate-capl-cluster-manifests:
 create-capl-cluster:
 	# Create a CAPL cluster without CSI driver and wait for it to be ready
 	kubectl apply -f capl-cluster-manifests.yaml
-	kubectl wait --for=condition=ControlPlaneReady  cluster/$(CLUSTER_NAME) --timeout=600s || (kubectl get cluster -o yaml; kubectl get linodecluster -o yaml; kubectl get linodemachines -o yaml)
+	kubectl wait --for=condition=ControlPlaneReady cluster/$(CLUSTER_NAME) --timeout=600s || (kubectl get cluster -o yaml; kubectl get linodecluster -o yaml; kubectl get linodemachines -o yaml)
+	kubectl wait --for=condition=Ready=true machines --all --timeout=900s
 	clusterctl get kubeconfig $(CLUSTER_NAME) > test-cluster-kubeconfig.yaml
+	KUBECONFIG=test-cluster-kubeconfig.yaml kubectl wait --for=condition=Ready nodes --all --timeout=600s
 	cat tests/e2e/setup/linode-secret.yaml | envsubst | KUBECONFIG=test-cluster-kubeconfig.yaml kubectl apply -f -
 
 .PHONY: generate-csi-driver-manifests


### PR DESCRIPTION
### Change:

We need to wait for all the nodes to come up before moving on testing. Previously we only waited for control plane nodes to come up but now we are waiting for all nodes. We also set worker nodes to 1 as default.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

