### PR TITLE
[Bug Fix] AttachVolume error where volume region is empty

### DIFF
--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -187,7 +187,7 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 
 	// Check if the volume exists and is valid.
 	// If the volume is already attached to the specified instance, it returns its device path.
-	devicePath, err := cs.getAndValidateVolume(ctx, volumeID, instance, req.GetVolumeContext())
+	devicePath, err := cs.getAndValidateVolume(ctx, volumeID, instance)
 	if err != nil {
 		metrics.RecordMetrics(metrics.ControllerPublishVolumeTotal, metrics.ControllerPublishVolumeDuration, metrics.Failed, functionStartTime)
 		return resp, err

--- a/internal/driver/controllerserver_helper.go
+++ b/internal/driver/controllerserver_helper.go
@@ -584,8 +584,8 @@ func (cs *ControllerServer) getAndValidateVolume(ctx context.Context, volumeID i
 	}
 
 	// check if the volume and instance are in the same region
-	if instance.Region != volContext[VolumeTopologyRegion] {
-		return "", errRegionMismatch(volContext[VolumeTopologyRegion], instance.Region)
+	if instance.Region != volume.Region {
+		return "", errRegionMismatch(volume.Region, instance.Region)
 	}
 
 	log.V(4).Info("Volume validated and is not attached to instance", "volume_id", volume.ID, "node_id", instance.ID)

--- a/internal/driver/controllerserver_helper.go
+++ b/internal/driver/controllerserver_helper.go
@@ -563,7 +563,7 @@ func (cs *ControllerServer) validateControllerPublishVolumeRequest(ctx context.C
 //
 // Additionally, it checks if the volume and instance are in the same region based on
 // the provided volume context. If they are not in the same region, it returns an internal error.
-func (cs *ControllerServer) getAndValidateVolume(ctx context.Context, volumeID int, instance *linodego.Instance, volContext map[string]string) (string, error) {
+func (cs *ControllerServer) getAndValidateVolume(ctx context.Context, volumeID int, instance *linodego.Instance) (string, error) {
 	log := logger.GetLogger(ctx)
 	log.V(4).Info("Entering getAndValidateVolume()", "volumeID", volumeID, "linodeID", instance.ID)
 	defer log.V(4).Info("Exiting getAndValidateVolume()")

--- a/internal/driver/controllerserver_helper_test.go
+++ b/internal/driver/controllerserver_helper_test.go
@@ -676,10 +676,6 @@ func TestGetAndValidateVolume(t *testing.T) {
 		client: mockClient,
 	}
 
-	volContext := map[string]string{
-		VolumeTopologyRegion: "us-east",
-	}
-
 	testCases := []struct {
 		name           string
 		volumeID       int
@@ -768,7 +764,7 @@ func TestGetAndValidateVolume(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMocks()
 
-			result, err := cs.getAndValidateVolume(context.Background(), tc.volumeID, tc.linode, volContext)
+			result, err := cs.getAndValidateVolume(context.Background(), tc.volumeID, tc.linode)
 
 			if err != nil && !reflect.DeepEqual(tc.expectedError, err) {
 				t.Errorf("expected error %v, got %v", tc.expectedError, err)

--- a/internal/driver/controllerserver_helper_test.go
+++ b/internal/driver/controllerserver_helper_test.go
@@ -711,6 +711,7 @@ func TestGetAndValidateVolume(t *testing.T) {
 				mockClient.EXPECT().GetVolume(gomock.Any(), 123).Return(&linodego.Volume{
 					ID:       123,
 					LinodeID: nil,
+					Region:   "us-east",
 				}, nil)
 			},
 			expectedResult: "",


### PR DESCRIPTION
volumeContext[VolumeTopologyRegion] was not a reliable source to get volumes region. We saw multiple instances where this was returning an empty string which was causing the region mismatch failure. Switching to just use volume obj returned by API to validate is a better and more robust approach since LinodeVolume Obj returned by the API will always have the correct region field.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

