### PR TITLE
chore: shrink useless data in go binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,11 @@ RUN apk add cryptsetup cryptsetup-libs cryptsetup-dev gcc musl-dev pkgconfig
 
 RUN go mod download
 
-RUN CGO_ENABLED=1 go build -a -ldflags '-X main.vendorVersion='${REV}'' -o /bin/linode-blockstorage-csi-driver /linode
+RUN CGO_ENABLED=1 go build -a -ldflags '-w -s -X main.vendorVersion="${REV}"' -o /bin/linode-blockstorage-csi-driver /linode
 
 FROM alpine:3.20.3
 LABEL maintainers="Linode"
 LABEL description="Linode CSI Driver"
-
-COPY --from=builder /bin/linode-blockstorage-csi-driver /linode
 
 RUN apk add --no-cache e2fsprogs findmnt blkid cryptsetup
 RUN apk add --no-cache xfsprogs=6.2.0-r2 --repository=http://dl-cdn.alpinelinux.org/alpine/v3.18/main


### PR DESCRIPTION
This saves ~7Mb on binary size.

With #316, image goes from 58.7MB to 28.2MB.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

