### PR TITLE
[improvement] : update helm chart to pass env vars and volumes

### DIFF
--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -91,7 +91,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: LINODE_URL
-              value: https://api.linode.com/v4
+              value: https://api.linode.com
             - name: LINODE_VOLUME_LABEL_PREFIX
               value: {{ .Values.volumeLabelPrefix | default "" | quote }}
             - name: NODE_NAME
@@ -112,6 +112,9 @@ spec:
               value: {{.Values.enableTracing | quote}}
             - name: OTEL_TRACING_PORT
               value: {{.Values.tracingPort | quote}}
+            {{- with .Values.csiLinodePlugin.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.csiLinodePlugin.pullPolicy }}
           name: csi-linode-plugin
@@ -122,6 +125,9 @@ spec:
               name: get-linode-id
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+            {{- with .Values.csiLinodePlugin.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       initContainers:
         - command:
             - /scripts/get-linode-id.sh
@@ -167,3 +173,6 @@ spec:
             path: /dev
             type: Directory
           name: dev
+        {{- with .Values.csiLinodePlugin.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
         - name: CSI_ENDPOINT
           value: unix:///csi/csi.sock
         - name: LINODE_URL
-          value: https://api.linode.com/v4
+          value: https://api.linode.com
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -56,6 +56,9 @@ spec:
           value: {{ .Values.enableMetrics | quote}}
         - name: METRICS_PORT
           value: {{ .Values.metricsPort | quote}}
+        {{- with .Values.csiLinodePlugin.env }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.csiLinodePlugin.pullPolicy }}
         name: csi-linode-plugin
@@ -79,6 +82,9 @@ spec:
           name: device-dir
         - mountPath: /tmp
           name: tmp
+        {{- with .Values.csiLinodePlugin.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       hostNetwork: true
       initContainers:
       - command:
@@ -158,3 +164,6 @@ spec:
           path: /tmp
           type: Directory
         name: tmp
+      {{- with .Values.csiLinodePlugin.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -68,6 +68,19 @@ csiLinodePlugin:
   tag:  # only set if required, defaults to .Chart.AppVersion set during release or "latest" by default
   pullPolicy: IfNotPresent
   podsMountDir: /var/lib/kubelet
+  # This section adds the ability to pass environment variables to adjust CSI defaults
+  env:
+  #  - name: EXAMPLE_ENV_VAR
+  #    value: "true"
+  # This section adds the ability to pass volumes to the DaemonSet
+  volumes:
+  #  - name: test-volume
+  #    emptyDir:
+  #      sizeLimit: 500Mi
+  # this section adds the ability to pass volumeMounts to the container
+  volumeMounts:
+  #  - mountPath: /tmp/
+  #    name: test-volume
 
 kubectl:
   image: alpine/k8s  # This needs to be alpine based and have both kubectl and curl installed.


### PR DESCRIPTION
### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

This PR allows us to pass environment vars and volumes to CSI driver from helm chart. This will help us to run CSI driver in different environments by just setting the env vars. Following secret and env vars needs to be set to run it in a custom env:
Secret:
```
kind: Secret
apiVersion: v1
metadata:
  name: linode-ca
  namespace: kube-system
data:
  cacert.pem: ${LINODE_CA_BASE64:=""}
```
Vars:
```
export LINODE_URL=<env specific API path>
export LINODE_CA_BASE64=<base64 encoded value of LINODE_CA cert content>
```

Helm chart updates:
```
    csiLinodePlugin:
      env:
        - name: LINODE_URL
          value: ${LINODE_URL:="https://api.linode.com"}
        - name: SSL_CERT_DIR
          value: "/tls"
      volumeMounts:
        - name: cacert
          mountPath: /tls
          readOnly: true
      volumes:
        - name: cacert
          secret:
            secretName: linode-ca
            defaultMode: 420
```