### PR TITLE
[improvement] : remove custom logic from linodeclient, use UseURL method

### DIFF
--- a/pkg/linode-client/linode_client.go
+++ b/pkg/linode-client/linode_client.go
@@ -2,9 +2,6 @@ package linodeclient
 
 import (
 	"context"
-	"fmt"
-	"net/url"
-	"strings"
 
 	"github.com/linode/linodego"
 )
@@ -37,46 +34,12 @@ type LinodeClient interface {
 func NewLinodeClient(token, ua, apiURL string) (*linodego.Client, error) {
 	// Use linodego built-in http client which supports setting root CA cert
 	linodeClient := linodego.NewClient(nil)
-	linodeClient.SetUserAgent(ua)
-	linodeClient.SetToken(token)
-
-	if apiURL != "" {
-		host, version, err := getAPIURLComponents(apiURL)
-		if err != nil {
-			return nil, err
-		}
-
-		linodeClient.SetBaseURL(host)
-
-		if version != "" {
-			linodeClient.SetAPIVersion(version)
-		}
-	}
-
-	return &linodeClient, nil
-}
-
-// getAPIURLComponents returns the API URL components (base URL, api version) given an input URL.
-// This is necessary due to some recent changes with how linodego handles
-// client.SetBaseURL(...) and client.SetAPIVersion(...)
-func getAPIURLComponents(apiURL string) (host, version string, err error) {
-	urlObj, err := url.Parse(apiURL)
+	client, err := linodeClient.UseURL(apiURL)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
+	client.SetUserAgent(ua)
+	client.SetToken(token)
 
-	version = ""
-	host = fmt.Sprintf("%s://%s", urlObj.Scheme, urlObj.Host)
-
-	// Check if the URL path is not empty
-	if strings.TrimPrefix(urlObj.Path, "/") != "" {
-		// Split the path into segments
-		pathSegments := strings.Split(strings.TrimPrefix(urlObj.Path, "/"), "/")
-		// If there are any segments, the first one is the API version
-		if len(pathSegments) > 0 {
-			version = pathSegments[0]
-		}
-	}
-
-	return host, version, nil
+	return client, nil
 }


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:
This PR removes the custom logic in CSI driver to parse the API URL. We now have UseURL method in linodego which does all the work of setting things correctly based on passed URL. This PR updates CSI driver to use that method instead of SetBaseURL.

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

