### PR TITLE
set securityContext for Pods and containers

### DIFF
--- a/deploy/kubernetes/base/ds-csi-linode-node.yaml
+++ b/deploy/kubernetes/base/ds-csi-linode-node.yaml
@@ -15,6 +15,9 @@ spec:
         app: csi-linode-node
         role: csi-linode
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-node-critical
       serviceAccount: csi-node-sa
       hostNetwork: true
@@ -34,6 +37,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -59,10 +67,15 @@ spec:
                   key: token
           imagePullPolicy: "Always"
           securityContext:
+            # This container must run as privileged due to the requirement for bidirectional mount propagation
+            # See https://github.com/kubernetes/kubernetes/issues/94400
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - SYS_ADMIN
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/deploy/kubernetes/base/ss-csi-linode-controller.yaml
+++ b/deploy/kubernetes/base/ss-csi-linode-controller.yaml
@@ -17,6 +17,9 @@ spec:
         app: csi-linode-controller
         role: csi-linode
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccount: csi-controller-sa
       containers:
         - name: csi-provisioner
@@ -32,6 +35,11 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -44,6 +52,11 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -56,6 +69,11 @@ spec:
           env:
           - name: ADDRESS
             value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - name: socket-dir
             mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -79,6 +97,11 @@ spec:
                 secretKeyRef:
                   name: linode
                   key: token
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -17,6 +17,9 @@ spec:
         app: csi-linode-controller
         role: csi-linode
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args:
             - --default-fstype=ext4
@@ -40,6 +43,11 @@ spec:
               containerPort: {{ .Values.csiProvisioner.metrics.port }}
               protocol: TCP
           {{- end}}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -61,6 +69,11 @@ spec:
               containerPort: {{ .Values.csiAttacher.metrics.port }}
               protocol: TCP
           {{- end}}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -82,6 +95,11 @@ spec:
               containerPort: {{ .Values.csiResizer.metrics.port }}
               protocol: TCP
           {{- end}}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -118,6 +136,11 @@ spec:
           image: {{ .Values.csiLinodePlugin.image }}:{{ .Values.csiLinodePlugin.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.csiLinodePlugin.pullPolicy }}
           name: csi-linode-plugin
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir

--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -15,6 +15,9 @@ spec:
         app: csi-linode-node
         role: csi-linode
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - args:
         - --v=2
@@ -31,6 +34,11 @@ spec:
               fieldPath: spec.nodeName
         image: {{ .Values.csiNodeDriverRegistrar.image}}:{{ .Values.csiNodeDriverRegistrar.tag}}
         name: csi-node-driver-registrar
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -63,11 +71,15 @@ spec:
         imagePullPolicy: {{ .Values.csiLinodePlugin.pullPolicy }}
         name: csi-linode-plugin
         securityContext:
+          # This container must run as privileged due to the requirement for bidirectional mount propagation
+          # See https://github.com/kubernetes/kubernetes/issues/94400
+          privileged: true
           allowPrivilegeEscalation: true
           capabilities:
+            drop:
+            - ALL
             add:
             - SYS_ADMIN
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir

--- a/internal/driver/deploy/releases/linode-blockstorage-csi-driver.yaml
+++ b/internal/driver/deploy/releases/linode-blockstorage-csi-driver.yaml
@@ -296,6 +296,11 @@ spec:
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -308,6 +313,11 @@ spec:
         image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -320,6 +330,11 @@ spec:
         image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -343,9 +358,17 @@ spec:
               name: linode
         image: linode/linode-blockstorage-csi-driver:latest
         name: csi-linode-plugin
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccount: csi-controller-sa
       tolerations:
       - effect: NoSchedule
@@ -357,10 +380,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: socket-dir
-      - configMap:
-          defaultMode: 493
-          name: get-linode-id
-        name: get-linode-id
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -395,6 +414,11 @@ spec:
               fieldPath: spec.nodeName
         image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
         name: csi-node-driver-registrar
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -424,6 +448,8 @@ spec:
           capabilities:
             add:
             - SYS_ADMIN
+            drop:
+            - ALL
           privileged: true
         volumeMounts:
         - mountPath: /csi
@@ -437,6 +463,9 @@ spec:
           name: tmp
       hostNetwork: true
       priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccount: csi-node-sa
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
This explicitly sets the securityContext on the Pods and containers and tries to restrict permissions where possible for privileged containers. Specifically, the csi-linode-plugin container needed to be allowed due to the Bidirectional volume mount propagation requirement but the other containers were set to not allow privileged permissions.
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

