### PR TITLE
chore: return notFound when disk isn't attached

### DIFF
--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -179,7 +179,7 @@ func (ns *NodeServer) findDevicePath(ctx context.Context, key linodevolumes.Lino
 
 	// If no device path is found, return an error.
 	if devicePath == "" {
-		return "", errInternal("Unable to find device path out of attempted paths: %v", devicePaths)
+		return "", errNotFound("Unable to find device path out of attempted paths: %v", devicePaths)
 	}
 
 	// If a device path is found, return it.

--- a/internal/driver/nodeserver_helpers_test.go
+++ b/internal/driver/nodeserver_helpers_test.go
@@ -226,7 +226,7 @@ func TestNodeServer_findDevicePath(t *testing.T) {
 				dUtils.EXPECT().VerifyDevicePath(gomock.Any()).Return("", nil)
 			},
 			wantDevicePath: "",
-			wantErr:        errInternal("Unable to find device path out of attempted paths: [some/path]"),
+			wantErr:        errNotFound("Unable to find device path out of attempted paths: [some/path]"),
 		},
 		{
 			name: "Success",


### PR DESCRIPTION
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/5a645a4b2fe29a52bba3305365c5918d049f1cf0/pkg/csi/service/osutils/linux_os_utils.go#L870

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

