### PR TITLE
Csioffline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          verify: false
       - run: make build
       - run: go test -cover ./... -coverprofile ./coverage.out
       - name: Upload coverage reports to Codecov
@@ -83,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
 
       - name: Login to Docker Hub
@@ -91,7 +92,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-  
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.12.0
 

--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -409,7 +409,8 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 		NextToken: nextToken,
 	}
 
-	log.V(2).Info("Volumes listed", "response", resp)
+	log.V(2).Info("Volumes listed")
+	log.V(6).Info("Volumes listed", "response", resp)
 	return resp, nil
 }
 
@@ -483,7 +484,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	log.V(2).Info("Volume resized successfully", "volume_id", volumeID)
 	resp = &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         size,
-		NodeExpansionRequired: false,
+		NodeExpansionRequired: true,
 	}
 	return resp, nil
 }

--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -458,7 +458,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	log.V(4).Info("Checking if volume exists", "volume_id", volumeID)
 	vol, err := cs.client.GetVolume(ctx, volumeID)
 	if err != nil {
-		return resp, errInternal("get volume: %v", err)
+		return resp, errNotFound("get volume: %v", err)
 	}
 
 	// Is the caller trying to resize the volume to be smaller than it currently is?

--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -414,4 +415,19 @@ func (ns *NodeServer) resize(devicePath, volumePath string) (bool, error) {
 	}
 
 	return needResize, nil
+}
+
+// getDeviceSize returns the size of the device at the given path.
+// size is returned in bytes.
+func (ns *NodeServer) getDeviceSize(devicePath string) (uint64, error) {
+	output, err := ns.mounter.Exec.Command("blockdev", "--getsize64", devicePath).CombinedOutput()
+	outStr := strings.TrimSpace(string(output))
+	if err != nil {
+		return 0, fmt.Errorf("failed to read size of device %s: %w: %s", devicePath, err, outStr)
+	}
+	size, err := strconv.ParseUint(outStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse size of device %s %s: %w", devicePath, outStr, err)
+	}
+	return size, nil
 }

--- a/tests/e2e/test/pod-pvc-unexpected-reboot/chainsaw-test.yaml
+++ b/tests/e2e/test/pod-pvc-unexpected-reboot/chainsaw-test.yaml
@@ -8,6 +8,13 @@ metadata:
     all:
     basic:
 spec:
+  description:
+    This test validates the behavior of a Pod with PVC when a node is unexpectedly rebooted.
+    1. Create a Pod with PVC.
+    2. Validate the Pod is running.
+    3. Reboot the node of the Pod.
+    4. Validate the Pod is running after the reboot.
+  skip: true
   concurrent: false
   bindings:
     - name: nodes

--- a/tests/e2e/test/pod-pvc-unexpected-reboot/chainsaw-test.yaml
+++ b/tests/e2e/test/pod-pvc-unexpected-reboot/chainsaw-test.yaml
@@ -129,7 +129,7 @@ spec:
         - wait:
             apiVersion: v1
             kind: Node
-            timeout: 120s
+            timeout: 5m
             name: ($nodeName)
             for:
               condition:
@@ -171,3 +171,9 @@ spec:
         - describe:
             apiVersion: v1
             kind: Pod
+            name: e2e-pod
+            namespace: ($namespace)
+        - describe:
+            apiVersion: v1
+            kind: PersistentVolumeClaim
+            namespace: ($namespace)

--- a/tests/e2e/test/sts-pvc-unexpected-reboot/chainsaw-test.yaml
+++ b/tests/e2e/test/sts-pvc-unexpected-reboot/chainsaw-test.yaml
@@ -74,6 +74,19 @@ spec:
                 value: ($namespace)
             content: |
               kubectl debug -n $NAMESPACE node/$NODE_NAME --profile=sysadmin --image=busybox -- chroot /host/ reboot --force
+        - assert:
+            timeout: 5m
+            resource:
+              apiVersion: v1
+              kind: Event
+              reason: NodeNotReady
+              source:
+                component: node-controller
+              involvedObject:
+                apiVersion: v1
+                kind: Pod
+                name: redis-test-0
+                namespace: ($namespace)
         - patch:
             # force sts on another node with nodeAffinity
             resource:
@@ -93,22 +106,10 @@ spec:
                                   operator: NotIn
                                   values:
                                     - ($nodeName)
-        - assert:
-            resource:
-              apiVersion: v1
-              kind: Event
-              reason: NodeNotReady
-              source:
-                component: node-controller
-              involvedObject:
-                apiVersion: v1
-                kind: Pod
-                name: redis-test-0
-                namespace: ($namespace)
         - wait:
             apiVersion: v1
             kind: Node
-            timeout: 120s
+            timeout: 5m
             name: ($nodeName)
             for:
               condition:
@@ -148,5 +149,11 @@ spec:
               (contains($stdout, 'testfile')): true
       catch:
         - describe:
-            apiVersion: apps/v1
-            kind: StatefulSet
+            apiVersion: v1
+            kind: Pod
+            name: redis-test-0
+            namespace: ($namespace)
+        - describe:
+            apiVersion: v1
+            kind: PersistentVolumeClaim
+            namespace: ($namespace)

--- a/tests/e2e/test/sts-pvc-unexpected-reboot/chainsaw-test.yaml
+++ b/tests/e2e/test/sts-pvc-unexpected-reboot/chainsaw-test.yaml
@@ -8,7 +8,14 @@ metadata:
     all:
     basic:
 spec:
+  description: |
+    This test validates the behavior of a StatefulSet with PVCs when a node is unexpectedly rebooted.
+    1. Create a StatefulSet with PVCs.
+    2. Validate the StatefulSet is running.
+    3. Reboot the node of the StatefulSet.
+    4. Validate the StatefulSet is running after the reboot.
   concurrent: false
+  skip: true
   bindings:
     - name: nodes
       # number of nodes in cluster


### PR DESCRIPTION
The main goal of this PR is to reflect current Linode volume behavior.
1) controller resize PV
2) controller ask for node resizing
3) node resizing fail with precondition failing: pv have to be moved
    - if volume size in API != real disk size -> need to be moved (detach / attach)
4) when moved, resizing is done and pod can used space


Example:
- editing PVC adding space
- describe pvc
  ```
     Warning  ExternalExpanding         13s (x14 over 4d1h)   volume_expand                             waiting for an external controller to expand this PVC
     Normal   Resizing                  13s (x16 over 9m21s)  external-resizer linodebs.csi.linode.com  External resizer is resizing volume pvc-91e59a56f0ce4260
     Normal   FileSystemResizeRequired  7s                    external-resizer linodebs.csi.linode.com  Require file system resize of volume on node
  ```
- `kubectl cordon node`
- `kubectl delete pod NAME`
- `kubectl describe pod NAME`
  ```
    Normal   SuccessfulAttachVolume      8s               attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-91e59a56f0ce4260"
    Normal   FileSystemResizeSuccessful  7s (x2 over 7s)  kubelet                  MountVolume.NodeExpandVolume succeeded for volume "pvc-91e59a56f0ce4260" glettron-worker-0
  ```
- `kubectl describe pvc`
  ```
    Normal   FileSystemResizeSuccessful  33s (x2 over 33s)     kubelet                                    MountVolume.NodeExpandVolume succeeded for volume "pvc-91e59a56f0ce4260" glettron-worker-0
  ```

This pull request includes several changes to the CI workflow, controller server, node server, and test files to improve error handling, logging, and test coverage.

### CI Workflow Improvements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR51): Added `verify: false` to `golangci-lint-action` and changed the `go-version-file` value to use double quotes. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR51) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL86-R87)

### Controller Server Enhancements:
* [`internal/driver/controllerserver.go`](diffhunk://#diff-1d4fec75f9b92a2e4ee64713b6af494eb664c2f3e16d4f14a9f79b7d731a27edL270-R270): Modified error handling in `ControllerUnpublishVolume`, `ListVolumes`, and `ControllerExpandVolume` functions to return more specific errors and adjusted logging levels. [[1]](diffhunk://#diff-1d4fec75f9b92a2e4ee64713b6af494eb664c2f3e16d4f14a9f79b7d731a27edL270-R270) [[2]](diffhunk://#diff-1d4fec75f9b92a2e4ee64713b6af494eb664c2f3e16d4f14a9f79b7d731a27edL412-R413) [[3]](diffhunk://#diff-1d4fec75f9b92a2e4ee64713b6af494eb664c2f3e16d4f14a9f79b7d731a27edL461-R462) [[4]](diffhunk://#diff-1d4fec75f9b92a2e4ee64713b6af494eb664c2f3e16d4f14a9f79b7d731a27edL486-R487)
* [`internal/driver/controllerserver_test.go`](diffhunk://#diff-ec8dffbfddb00f9ded2ae273ba001198a89910521d1dffd3595c1b2c7c1ecf7eL427-R427): Updated tests for `ControllerExpandVolume` to include new scenarios and expectations. [[1]](diffhunk://#diff-ec8dffbfddb00f9ded2ae273ba001198a89910521d1dffd3595c1b2c7c1ecf7eL427-R427) [[2]](diffhunk://#diff-ec8dffbfddb00f9ded2ae273ba001198a89910521d1dffd3595c1b2c7c1ecf7eL441-R460)

### Node Server Enhancements:
* [`internal/driver/nodeserver.go`](diffhunk://#diff-4c9884e616aca38b30c85e294771edb372910782197345c1add488171278301aR413-R438): Added checks for volume size discrepancies and implemented a new method `getDeviceSize` to retrieve device size. [[1]](diffhunk://#diff-4c9884e616aca38b30c85e294771edb372910782197345c1add488171278301aR413-R438) [[2]](diffhunk://#diff-6ed7d51a9a9e44d11bbfb697256c7d8be443c00d2696bcbd0ee41afb8c3326f5R419-R433)
* [`internal/driver/nodeserver_helpers.go`](diffhunk://#diff-6ed7d51a9a9e44d11bbfb697256c7d8be443c00d2696bcbd0ee41afb8c3326f5R22): Added import for `strconv` and implemented the `getDeviceSize` function. [[1]](diffhunk://#diff-6ed7d51a9a9e44d11bbfb697256c7d8be443c00d2696bcbd0ee41afb8c3326f5R22) [[2]](diffhunk://#diff-6ed7d51a9a9e44d11bbfb697256c7d8be443c00d2696bcbd0ee41afb8c3326f5R419-R433)
* [`internal/driver/nodeserver_test.go`](diffhunk://#diff-534d005da056572ec186480b1fb4a744e78f6607ed2b2b4895d047a7cbe91f59R481): Enhanced `TestNodeExpandVolume` to include new mock expectations for volume size checks. [[1]](diffhunk://#diff-534d005da056572ec186480b1fb4a744e78f6607ed2b2b4895d047a7cbe91f59R481) [[2]](diffhunk://#diff-534d005da056572ec186480b1fb4a744e78f6607ed2b2b4895d047a7cbe91f59R500-R510) [[3]](diffhunk://#diff-534d005da056572ec186480b1fb4a744e78f6607ed2b2b4895d047a7cbe91f59R541-R551) [[4]](diffhunk://#diff-534d005da056572ec186480b1fb4a744e78f6607ed2b2b4895d047a7cbe91f59R657-R659)

### Test Coverage Improvements:
* [`tests/e2e/test/pod-pvc-unexpected-reboot/chainsaw-test.yaml`](diffhunk://#diff-5406107643aee26e0611934b41c4c88b9cc42027feca03321049ba894bf9066aR11-R17): Added description and steps for the test, increased timeout for node wait, and added descriptions for Pod and PVC. [[1]](diffhunk://#diff-5406107643aee26e0611934b41c4c88b9cc42027feca03321049ba894bf9066aR11-R17) [[2]](diffhunk://#diff-5406107643aee26e0611934b41c4c88b9cc42027feca03321049ba894bf9066aL132-R139) [[3]](diffhunk://#diff-5406107643aee26e0611934b41c4c88b9cc42027feca03321049ba894bf9066aR181-R186)
* [`tests/e2e/test/sts-pvc-unexpected-reboot/chainsaw-test.yaml`](diffhunk://#diff-4dfa25c211cbf917171fc9456555f9d8f2fefc8b6df0016d017eff05da24216bR11-R18): Added description and steps for the test, increased timeout for node wait, and added descriptions for Pod and PVC. [[1]](diffhunk://#diff-4dfa25c211cbf917171fc9456555f9d8f2fefc8b6df0016d017eff05da24216bR11-R18) [[2]](diffhunk://#diff-4dfa25c211cbf917171fc9456555f9d8f2fefc8b6df0016d017eff05da24216bR84-R96) [[3]](diffhunk://#diff-4dfa25c211cbf917171fc9456555f9d8f2fefc8b6df0016d017eff05da24216bL96-R119) [[4]](diffhunk://#diff-4dfa25c211cbf917171fc9456555f9d8f2fefc8b6df0016d017eff05da24216bL151-R166)


### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

