### PR TITLE
fix: persist pv on reboot

### DIFF
--- a/internal/driver/controllerserver_helper.go
+++ b/internal/driver/controllerserver_helper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/linode/linodego"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/utils/ptr"
 
 	linodevolumes "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-volumes"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/logger"
@@ -783,12 +784,11 @@ func (cs *ControllerServer) attachVolume(ctx context.Context, volumeID, linodeID
 		defer span.End()
 	}
 
-	persist := false
-	_, err := cs.client.AttachVolume(ctx, volumeID, &linodego.VolumeAttachOptions{
+	// Attempt to attach the volume to the Linode instance.
+	if _, err := cs.client.AttachVolume(ctx, volumeID, &linodego.VolumeAttachOptions{
 		LinodeID:           linodeID,
-		PersistAcrossBoots: &persist,
-	})
-	if err != nil {
+		PersistAcrossBoots: ptr.To(true),
+	}); err != nil {
 		code := codes.Internal // Default error code is Internal.
 		// Check if the error indicates that the volume is already attached.
 		var apiErr *linodego.Error


### PR DESCRIPTION
CSI don't detach pv on node reboot.
csiattachement still exists even if pv have been removed. Persist on reboot permit to have same behavior as all other clouds.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

