### PR TITLE
feat(volume): and a mounting option for different distros 

### DIFF
--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -27,11 +27,14 @@ spec:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
-          value: /var/lib/kubelet/plugins/linodebs.csi.linode.com/csi.sock
+          value: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins/linodebs.csi.linode.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        {{- with .Values.csiNodeDriverRegistrar.env }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: {{ .Values.csiNodeDriverRegistrar.image}}:{{ .Values.csiNodeDriverRegistrar.tag}}
         name: csi-node-driver-registrar
         securityContext:
@@ -42,8 +45,11 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
-        - mountPath: /registration
+        - mountPath: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins_registry
           name: registration-dir
+        {{- with .Values.csiNodeDriverRegistrar.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       - args:
         - --v=2
         env:
@@ -100,15 +106,15 @@ spec:
         operator: Exists
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins_registry/
+          path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins_registry/
           type: DirectoryOrCreate
         name: registration-dir
       - hostPath:
-          path: /var/lib/kubelet
+          path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}
           type: Directory
         name: kubelet-dir
       - hostPath:
-          path: /var/lib/kubelet/plugins/linodebs.csi.linode.com
+          path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins/linodebs.csi.linode.com
           type: DirectoryOrCreate
         name: plugin-dir
       - hostPath:

--- a/helm-chart/csi-driver/templates/daemonset.yaml
+++ b/helm-chart/csi-driver/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
-        - mountPath: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins_registry
+        - mountPath: /registration
           name: registration-dir
         {{- with .Values.csiNodeDriverRegistrar.volumeMounts }}
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -23,6 +23,9 @@ volumeLabelPrefix: ""
 # Default namespace is "kube-system" but it can be set to another namespace
 namespace: kube-system
 
+# Add a kubelet path variable to be used across containers for alternate k8s distros (e.g K0s, K3s)
+kubeletPath: "/var/lib/kubelet"
+
 # Set these values if your APIToken and region are already present in a k8s secret.
 # secretRef:
 #   name: "linode"
@@ -91,6 +94,10 @@ kubectl:
 csiNodeDriverRegistrar:
   image: registry.k8s.io/sig-storage/csi-node-driver-registrar
   tag: v2.12.0
+  # Additional environment variables for the node driver registrar container
+  env: []
+  # Additional volume mounts for the node driver registrar container
+  volumeMounts: []
 
 controller:
   nodeSelector: {}


### PR DESCRIPTION
### General:

Related issue: #433 

Currently there is a bunch of hardcoded path in the helm templates which makes it very hard to run k0s or k3s on linode as they have different paths where the data is saved. Without This the csi driver will never register in the cluster and are unable to dynamically assign volumes in linode.

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

