### PR TITLE
[deps] Update CSI driver images to latest versions

### DIFF
--- a/deploy/kubernetes/base/ds-csi-linode-node.yaml
+++ b/deploy/kubernetes/base/ds-csi-linode-node.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/base/ss-csi-linode-controller.yaml
+++ b/deploy/kubernetes/base/ss-csi-linode-controller.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccount: csi-controller-sa
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--default-fstype=ext4"
@@ -44,7 +44,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
           imagePullPolicy: IfNotPresent
           args:
             - "--v=2"
@@ -62,7 +62,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
           imagePullPolicy: IfNotPresent
           args:
           - "--v=2"

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -44,7 +44,7 @@ defaultStorageClass: linode-block-storage-retain
 # Images - Default
 csiProvisioner:
   image: registry.k8s.io/sig-storage/csi-provisioner
-  tag: v5.1.0
+  tag: v5.3.0
   pullPolicy: IfNotPresent
   metrics:
     address: "0.0.0.0:10248"
@@ -52,7 +52,7 @@ csiProvisioner:
 
 csiAttacher:
   image: registry.k8s.io/sig-storage/csi-attacher
-  tag: v4.8.1
+  tag: v4.9.0
   pullPolicy: IfNotPresent
   metrics:
     address: "0.0.0.0:10249"
@@ -60,7 +60,7 @@ csiAttacher:
 
 csiResizer:
   image: registry.k8s.io/sig-storage/csi-resizer
-  tag: v1.12.0
+  tag: v1.14.0
   pullPolicy: IfNotPresent
   metrics:
     address: "0.0.0.0:10250"
@@ -93,7 +93,7 @@ kubectl:
 
 csiNodeDriverRegistrar:
   image: registry.k8s.io/sig-storage/csi-node-driver-registrar
-  tag: v2.12.0
+  tag: v2.14.0
   # Additional environment variables for the node driver registrar container
   env: []
   # Additional volume mounts for the node driver registrar container

--- a/internal/driver/deploy/releases/linode-blockstorage-csi-driver.yaml
+++ b/internal/driver/deploy/releases/linode-blockstorage-csi-driver.yaml
@@ -293,7 +293,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         securityContext:
@@ -310,7 +310,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
         securityContext:
@@ -328,7 +328,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
         securityContext:
@@ -413,7 +413,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
         name: csi-node-driver-registrar
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
- Updated csi-node-driver-registrar from v2.12.0 to v2.14.0 in ds-csi-linode-node.yaml
- Updated csi-provisioner from v5.1.0 to v5.3.0 in ss-csi-linode-controller.yaml and linode-blockstorage-csi-driver.yaml
- Updated csi-attacher from v4.8.1 to v4.9.0 in ss-csi-linode-controller.yaml and linode-blockstorage-csi-driver.yaml
- Updated csi-resizer from v1.12.0 to v1.14.0 in ss-csi-linode-controller.yaml and linode-blockstorage-csi-driver.yaml
- Updated image tags in helm-chart values.yaml for consistency

These updates ensure compatibility with the latest features and improvements in the CSI drivers.

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

