### PR TITLE
[improvement] Harden logging around CSI requests and LUKS errors

### DIFF
--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -65,7 +65,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	defer done()
 
 	functionStartTime := time.Now()
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "name", req.GetName(), "hasContentSource", req.GetVolumeContentSource() != nil)
 
 	// Validate the incoming request to ensure it meets the necessary criteria.
 	// This includes checking for required fields and valid volume capabilities.
@@ -130,7 +130,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		return &csi.DeleteVolumeResponse{}, statusErr
 	}
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "volume_id", volID)
 
 	// Check if the volume exists
 	log.V(4).Info("Checking if volume exists", "volume_id", volID)
@@ -172,7 +172,7 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	defer done()
 
 	functionStartTime := time.Now()
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "volume_id", req.GetVolumeId(), "node_id", req.GetNodeId())
 
 	// Validate the request and get Linode ID and Volume ID
 	linodeID, volumeID, err := cs.validateControllerPublishVolumeRequest(ctx, req)
@@ -252,7 +252,7 @@ func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	defer done()
 
 	functionStartTime := time.Now()
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "volume_id", req.GetVolumeId(), "node_id", req.GetNodeId())
 
 	volumeID, statusErr := linodevolumes.VolumeIdAsInt("ControllerUnpublishVolume", req)
 	if statusErr != nil {
@@ -319,7 +319,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	log, done := logger.WithMethod(log, "ValidateVolumeCapabilities")
 	defer done()
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "volume_id", req.GetVolumeId(), "capability_count", len(req.GetVolumeCapabilities()))
 
 	volumeID, statusErr := linodevolumes.VolumeIdAsInt("ControllerValidateVolumeCapabilities", req)
 	if statusErr != nil {
@@ -356,7 +356,7 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	log, done := logger.WithMethod(log, "ListVolumes")
 	defer done()
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "starting_token", req.GetStartingToken(), "max_entries", req.GetMaxEntries())
 
 	startingToken := req.GetStartingToken()
 	nextToken := ""
@@ -423,7 +423,7 @@ func (cs *ControllerServer) ControllerGetCapabilities(ctx context.Context, req *
 	log, done := logger.WithMethod(log, "ControllerGetCapabilities")
 	defer done()
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request")
 
 	resp := &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: cs.driver.cscap,
@@ -443,7 +443,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	log, done := logger.WithMethod(log, "ControllerExpandVolume")
 	defer done()
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "volume_id", req.GetVolumeId())
 
 	volumeID, statusErr := linodevolumes.VolumeIdAsInt("ControllerExpandVolume", req)
 	if statusErr != nil {
@@ -497,7 +497,7 @@ func (cs *ControllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 	log, done := logger.WithMethod(log, "ControllerGetVolume")
 	defer done()
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "volume_id", req.GetVolumeId())
 
 	volumeID, statusErr := linodevolumes.VolumeIdAsInt("ControllerGetVolume", req)
 	if statusErr != nil {

--- a/internal/driver/controllerserver_helper.go
+++ b/internal/driver/controllerserver_helper.go
@@ -440,7 +440,7 @@ func validVolumeCapabilities(caps []*csi.VolumeCapability) bool {
 // and that the capabilities are valid. Returns an error if any validation fails.
 func (cs *ControllerServer) validateCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeRequest) error {
 	log, ctx := logger.GetLogger(ctx)
-	log.V(4).Info("Entering validateCreateVolumeRequest()", "req", req)
+	log.V(4).Info("Entering validateCreateVolumeRequest()", "name", req.GetName(), "capability_count", len(req.GetVolumeCapabilities()))
 	defer log.V(4).Info("Exiting validateCreateVolumeRequest()")
 	if !observability.SkipObservability {
 		_, span := observability.StartFunctionSpan(ctx)
@@ -472,7 +472,7 @@ func (cs *ControllerServer) validateCreateVolumeRequest(ctx context.Context, req
 // and generates a normalized volume name. Returns the volume name and size in GB.
 func (cs *ControllerServer) prepareVolumeParams(ctx context.Context, req *csi.CreateVolumeRequest) (*VolumeParams, error) {
 	log, ctx := logger.GetLogger(ctx)
-	log.V(4).Info("Entering prepareVolumeParams()", "req", req)
+	log.V(4).Info("Entering prepareVolumeParams()", "name", req.GetName())
 	defer log.V(4).Info("Exiting prepareVolumeParams()")
 	if !observability.SkipObservability {
 		_, span := observability.StartFunctionSpan(ctx)
@@ -535,7 +535,7 @@ func (cs *ControllerServer) prepareVolumeParams(ctx context.Context, req *csi.Cr
 // If the volume is encrypted, it adds relevant encryption attributes to the context.
 func (cs *ControllerServer) createVolumeContext(ctx context.Context, req *csi.CreateVolumeRequest, vol *linodego.Volume) map[string]string {
 	log, ctx := logger.GetLogger(ctx)
-	log.V(4).Info("Entering createVolumeContext()", "req", req)
+	log.V(4).Info("Entering createVolumeContext()", "name", req.GetName(), "region", vol.Region)
 	defer log.V(4).Info("Exiting createVolumeContext()")
 	if !observability.SkipObservability {
 		_, span := observability.StartFunctionSpan(ctx)
@@ -553,7 +553,7 @@ func (cs *ControllerServer) createVolumeContext(ctx context.Context, req *csi.Cr
 
 	volumeContext[VolumeTopologyRegion] = vol.Region
 
-	log.V(4).Info("Volume context created", "volumeContext", volumeContext)
+	log.V(4).Info("Volume context created", "region", volumeContext[VolumeTopologyRegion], "luksEncrypted", volumeContext[LuksEncryptedAttribute] == True)
 	return volumeContext
 }
 
@@ -641,7 +641,7 @@ func (cs *ControllerServer) prepareCreateVolumeResponse(ctx context.Context, vol
 // an appropriate error.
 func (cs *ControllerServer) validateControllerPublishVolumeRequest(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (linodeID, volumeID int, err error) {
 	log, ctx := logger.GetLogger(ctx)
-	log.V(4).Info("Entering validateControllerPublishVolumeRequest()", "req", req)
+	log.V(4).Info("Entering validateControllerPublishVolumeRequest()", "volume_id", req.GetVolumeId(), "node_id", req.GetNodeId())
 	defer log.V(4).Info("Exiting validateControllerPublishVolumeRequest()")
 	if !observability.SkipObservability {
 		_, span := observability.StartFunctionSpan(ctx)

--- a/internal/driver/luks.go
+++ b/internal/driver/luks.go
@@ -165,7 +165,7 @@ func (e *Encryption) luksFormat(ctx context.Context, luksCtx *LuksContext, sourc
 	log.V(4).Info("Activating luks device using volumekey", "device", newLuksDevice.Identifier, "VolumeName", luksCtx.VolumeName)
 	err = newLuksDevice.Device.ActivateByPassphrase(luksCtx.VolumeName, 0, luksCtx.EncryptionKey, 0)
 	if err != nil {
-		return "", fmt.Errorf("activating %s luks device %s volumekey %s: %w", newLuksDevice.Identifier, luksCtx.VolumeName, luksCtx.EncryptionKey, err)
+		return "", fmt.Errorf("activating %s luks device %s: %w", newLuksDevice.Identifier, luksCtx.VolumeName, err)
 	}
 	log.V(4).Info("The LUKS volume is now ready", "volumeName", luksCtx.VolumeName)
 
@@ -188,7 +188,7 @@ func (e *Encryption) luksOpen(ctx context.Context, luksCtx *LuksContext, source 
 	log.V(4).Info("Loading luks device", "device", newLuksDevice.Identifier, "VolumeName", luksCtx.VolumeName)
 	err = newLuksDevice.Device.Load(cryptsetup.LUKS2{SectorSize: 512})
 	if err != nil {
-		return "", fmt.Errorf("loading %s luks device %s volumekey %s: %w", newLuksDevice.Identifier, luksCtx.VolumeName, luksCtx.EncryptionKey, err)
+		return "", fmt.Errorf("loading %s luks device %s: %w", newLuksDevice.Identifier, luksCtx.VolumeName, err)
 	}
 
 	// Activate the device using the encryption key
@@ -198,7 +198,7 @@ func (e *Encryption) luksOpen(ctx context.Context, luksCtx *LuksContext, source 
 		if errors.As(err, &apiErr) && apiErr.Code() == -17 {
 			return "/dev/mapper/" + luksCtx.VolumeName, nil
 		}
-		return "", fmt.Errorf("activating %s luks device %s volumekey %s: %w", newLuksDevice.Identifier, luksCtx.VolumeName, luksCtx.EncryptionKey, err)
+		return "", fmt.Errorf("activating %s luks device %s: %w", newLuksDevice.Identifier, luksCtx.VolumeName, err)
 	}
 
 	log.V(4).Info("The LUKS volume is now ready ", "volumeName", luksCtx.VolumeName)

--- a/internal/driver/nodeserver.go
+++ b/internal/driver/nodeserver.go
@@ -444,7 +444,7 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	log, done := logger.WithMethod(log, "NodeGetInfo")
 	defer done()
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request")
 
 	// Get the number of currently attached instance disks, and subtract it
 	// from the limit of block devices that can be attached to the instance,
@@ -479,7 +479,7 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	log, done := logger.WithMethod(log, "NodeGetVolumeStats")
 	defer done()
 
-	log.V(2).Info("Processing request", "req", req)
+	log.V(2).Info("Processing request", "volumeID", req.GetVolumeId(), "volumePath", req.GetVolumePath())
 
 	return nodeGetVolumeStats(ctx, req)
 }

--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -39,7 +39,7 @@ const (
 // It validates the volume ID, staging target path, and volume capability.
 func validateNodeStageVolumeRequest(ctx context.Context, req *csi.NodeStageVolumeRequest) error {
 	log, _ := logger.GetLogger(ctx)
-	log.V(4).Info("Entering validateNodeStageVolumeRequest", "req", req)
+	log.V(4).Info("Entering validateNodeStageVolumeRequest", "volumeID", req.GetVolumeId(), "stagingTargetPath", req.GetStagingTargetPath())
 
 	if req.GetVolumeId() == "" {
 		return errNoVolumeID
@@ -59,7 +59,7 @@ func validateNodeStageVolumeRequest(ctx context.Context, req *csi.NodeStageVolum
 // It validates the volume ID and staging target path.
 func validateNodeUnstageVolumeRequest(ctx context.Context, req *csi.NodeUnstageVolumeRequest) error {
 	log, _ := logger.GetLogger(ctx)
-	log.V(4).Info("Entering validateNodeUnstageVolumeRequest", "req", req)
+	log.V(4).Info("Entering validateNodeUnstageVolumeRequest", "volumeID", req.GetVolumeId(), "stagingTargetPath", req.GetStagingTargetPath())
 
 	if req.GetVolumeId() == "" {
 		return errNoVolumeID
@@ -76,7 +76,7 @@ func validateNodeUnstageVolumeRequest(ctx context.Context, req *csi.NodeUnstageV
 // It checks the volume ID and volume path in the provided request.
 func validateNodeExpandVolumeRequest(ctx context.Context, req *csi.NodeExpandVolumeRequest) error {
 	log, _ := logger.GetLogger(ctx)
-	log.V(4).Info("Entering validateNodeExpandVolumeRequest", "req", req)
+	log.V(4).Info("Entering validateNodeExpandVolumeRequest", "volumeID", req.GetVolumeId(), "volumePath", req.GetVolumePath())
 
 	if req.GetVolumeId() == "" {
 		return errNoVolumeID
@@ -93,7 +93,7 @@ func validateNodeExpandVolumeRequest(ctx context.Context, req *csi.NodeExpandVol
 // It checks the volume ID, staging target path, target path, and volume capability in the provided request.
 func validateNodePublishVolumeRequest(ctx context.Context, req *csi.NodePublishVolumeRequest) error {
 	log, _ := logger.GetLogger(ctx)
-	log.V(4).Info("Entering validateNodePublishVolumeRequest", "req", req)
+	log.V(4).Info("Entering validateNodePublishVolumeRequest", "volumeID", req.GetVolumeId(), "stagingTargetPath", req.GetStagingTargetPath(), "targetPath", req.GetTargetPath())
 
 	if req.GetVolumeId() == "" {
 		return errNoVolumeID
@@ -116,7 +116,7 @@ func validateNodePublishVolumeRequest(ctx context.Context, req *csi.NodePublishV
 // It checks the volume ID and target path in the provided request.
 func validateNodeUnpublishVolumeRequest(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) error {
 	log, _ := logger.GetLogger(ctx)
-	log.V(4).Info("Entering validateNodeUnpublishVolumeRequest", "req", req)
+	log.V(4).Info("Entering validateNodeUnpublishVolumeRequest", "volumeID", req.GetVolumeId(), "targetPath", req.GetTargetPath())
 
 	if req.GetVolumeId() == "" {
 		return errNoVolumeID
@@ -223,7 +223,7 @@ func (ns *NodeServer) ensureMountPoint(ctx context.Context, path string, fs file
 // It returns a CSI NodePublishVolumeResponse and an error if the operation fails.
 func (ns *NodeServer) nodePublishVolumeBlock(ctx context.Context, req *csi.NodePublishVolumeRequest, mountOptions []string, fs filesystem.FileSystem) (*csi.NodePublishVolumeResponse, error) {
 	log, _ := logger.GetLogger(ctx)
-	log.V(4).Info("Entering nodePublishVolumeBlock", "req", req, "mountOptions", mountOptions)
+	log.V(4).Info("Entering nodePublishVolumeBlock", "volumeID", req.GetVolumeId(), "targetPath", req.GetTargetPath(), "mountOptions", mountOptions)
 
 	targetPath := req.GetTargetPath()
 	targetPathDir := filepath.Dir(targetPath)
@@ -276,7 +276,7 @@ func (ns *NodeServer) nodePublishVolumeBlock(ctx context.Context, req *csi.NodeP
 // the filesystem type and mount options from the volume capability.
 func (ns *NodeServer) mountVolume(ctx context.Context, devicePath string, req *csi.NodeStageVolumeRequest) error {
 	log, ctx := logger.GetLogger(ctx)
-	log.V(4).Info("Entering mountVolume", "devicePath", devicePath, "req", req)
+	log.V(4).Info("Entering mountVolume", "devicePath", devicePath, "volumeID", req.GetVolumeId(), "stagingTargetPath", req.GetStagingTargetPath())
 
 	stagingTargetPath := req.GetStagingTargetPath()
 	volumeCapability := req.GetVolumeCapability()
@@ -321,7 +321,7 @@ func (ns *NodeServer) mountVolume(ctx context.Context, devicePath string, req *c
 // Finally, it prepares the LUKS volume for mounting.
 func (ns *NodeServer) formatLUKSVolume(ctx context.Context, devicePath string, luksContext *LuksContext) (luksSource string, err error) {
 	log, ctx := logger.GetLogger(ctx)
-	log.V(4).Info("Entering formatLUKSVolume", "devicePath", devicePath, "luksContext", luksContext)
+	log.V(4).Info("Entering formatLUKSVolume", "devicePath", devicePath, "encryptionEnabled", luksContext.EncryptionEnabled, "encryptionCipher", luksContext.EncryptionCipher, "encryptionKeySize", luksContext.EncryptionKeySize, "volumeName", luksContext.VolumeName, "volumeLifecycle", luksContext.VolumeLifecycle)
 
 	// LUKS encryption enabled, check if the volume needs to be formatted.
 	formatted, err := ns.encrypt.blkidValid(ctx, devicePath)


### PR DESCRIPTION
## Summary
This PR hardens driver logging to avoid exposing sensitive information while preserving useful operational context.

## What changed
- remove raw CSI request object logging from controller and node paths
- replace broad request and context logs with explicit safe fields like volume IDs, target paths, region, and capability counts
- remove the LUKS encryption key from wrapped error messages during device load and activation
- keep enough structured context in logs to debug request flow without serializing secret-bearing payloads

## Why
Some CSI request paths can carry secrets or secret-derived fields, especially in node staging flows that consume LUKS key material. Logging whole request objects or whole secret-bearing structs is not a safe default because future request fields or map contents can surface sensitive data unexpectedly.

The concrete leak fixed here was in LUKS error wrapping, where activation and load failures included the encryption key in the returned error string. This PR removes that key material from the error text while preserving the relevant device and volume context.

## Scope and tradeoffs
This change is intentionally narrow:
- it does not change request handling behavior
- it does not remove useful logging entirely
- it replaces broad object logging with field-level logging that is easier to reason about from a security perspective

## Validation
- ran gofmt on the touched Go files
- did not add or update tests for this change
