### PR TITLE
[ci] group Renovate GitHub Actions updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,12 @@
       "automerge": true,
     },
     {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "separateMajorMinor": false
+    },
+    {
       "groupName": "kubernetes",
       "groupSlug": "kubernetes-go",
       "matchDatasources": [


### PR DESCRIPTION
## Summary
- group Renovate updates managed by `github-actions` into a single PR
- set `separateMajorMinor` to `false` for that manager so action updates do not split into separate major/minor PRs

## Why
GitHub Actions updates are easier to review as one workflow-maintenance PR than as multiple PRs for the same set of actions. This reduces PR noise while keeping the existing grouping and automerge behavior for other dependency types unchanged.

## References
- Renovate `groupName`: https://docs.renovatebot.com/configuration-options/#groupname
- Renovate `separateMajorMinor`: https://docs.renovatebot.com/configuration-options/#separatemajorminor
- Renovate GitHub Actions manager: https://docs.renovatebot.com/modules/manager/github-actions/
