### PR TITLE
[improvement] Prioritize security Renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,11 @@
   ],
   "packageRules": [
     {
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
+      "prPriority": 10
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
     },


### PR DESCRIPTION
Security-flagged Renovate updates should bypass the normal schedule.

This keeps security PRs prioritized so they can be created as soon as possible.