### PR TITLE
[fix] Prefer PublishContext device paths in NodeStageVolume

### DIFF
--- a/internal/driver/nodeserver.go
+++ b/internal/driver/nodeserver.go
@@ -237,8 +237,8 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	log.V(4).Info("Finding device path", "volumeID", volumeID)
-	devicePath, err := ns.findDevicePath(ctx, *LinodeVolumeKey, partition)
+	log.V(4).Info("Resolving device path", "volumeID", volumeID)
+	devicePath, err := ns.resolveStageDevicePath(ctx, req, *LinodeVolumeKey, partition)
 	if err != nil {
 		observability.RecordMetrics(observability.NodeStageVolumeTotal, observability.NodeStageVolumeDuration, observability.Failed, functionStartTime)
 		return nil, err

--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -189,6 +189,27 @@ func (ns *NodeServer) findDevicePath(ctx context.Context, key linodevolumes.Lino
 	return devicePath, nil
 }
 
+// resolveStageDevicePath prefers the controller server provided device path when it is
+// available and locally verified, then falls back to the by-id st lookup.
+func (ns *NodeServer) resolveStageDevicePath(ctx context.Context, req *csi.NodeStageVolumeRequest, key linodevolumes.LinodeVolumeKey, partition string) (string, error) {
+	log, _ := logger.GetLogger(ctx)
+	log.V(4).Info("Entering resolveStageDevicePath", "volumeID", req.GetVolumeId(), "partition", partition)
+
+	if publishContext := req.GetPublishContext(); publishContext != nil {
+		if devicePath := publishContext[devicePathKey]; devicePath != "" {
+			verifiedDevicePath, err := ns.deviceutils.VerifyDevicePath([]string{devicePath})
+			if err == nil && verifiedDevicePath != "" {
+				log.V(4).Info("Using device path from PublishContext", "devicePath", verifiedDevicePath)
+				return verifiedDevicePath, nil
+			}
+
+			log.V(4).Info("PublishContext device path was not found on this node, falling back to local lookup", "devicePath", devicePath)
+		}
+	}
+
+	return ns.findDevicePath(ctx, key, partition)
+}
+
 // ensureMountPoint checks if the staging target path is a mount point or not.
 // If not, it creates a directory at the target path.
 func (ns *NodeServer) ensureMountPoint(ctx context.Context, path string, fs filesystem.FileSystem) (bool, error) {

--- a/internal/driver/nodeserver_test.go
+++ b/internal/driver/nodeserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -145,7 +146,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          "1000-stagehappypath",
 				StagingTargetPath: "/mnt/staging",
 				PublishContext: map[string]string{
-					"devicePath": "/dev/stagehappypath",
+					"devicePath": "/dev/sdc",
 				},
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -160,7 +161,7 @@ func TestNodeStageVolume(t *testing.T) {
 			expectedError: nil,
 			expectFSCalls: func(m *mocks.MockFileSystem) {
 				m.EXPECT().Glob("/dev/sd*").Return([]string{"/dev/sda", "/dev/sdb"}, nil).AnyTimes()
-				m.EXPECT().Stat("/dev/disk/by-id/linode-stagehappypath").Return(nil, nil)
+				m.EXPECT().Stat("/dev/sdc").Return(nil, nil)
 			},
 		},
 		{
@@ -169,7 +170,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          "1000-stageNoAccessMode",
 				StagingTargetPath: "/mnt/staging",
 				PublishContext: map[string]string{
-					"devicePath": "/dev/stageNoAccessMode",
+					"devicePath": "/dev/sdc",
 				},
 				VolumeCapability: &csi.VolumeCapability{},
 			},
@@ -184,7 +185,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          "foo",
 				StagingTargetPath: "/mnt/staging",
 				PublishContext: map[string]string{
-					"devicePath": "/dev/stageBadVolumeID",
+					"devicePath": "/dev/sdd",
 				},
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -203,7 +204,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          "1000-stageBlock",
 				StagingTargetPath: "/mnt/staging",
 				PublishContext: map[string]string{
-					"devicePath": "/dev/stageBadVolumeID",
+					"devicePath": "/dev/sde",
 				},
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -220,7 +221,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			expectFSCalls: func(m *mocks.MockFileSystem) {
 				m.EXPECT().Glob("/dev/sd*").Return([]string{"/dev/sda", "/dev/sdb"}, nil).AnyTimes()
-				m.EXPECT().Stat("/dev/disk/by-id/linode-stageBlock").Return(nil, nil)
+				m.EXPECT().Stat("/dev/sde").Return(nil, nil)
 			},
 			expectedError: nil,
 			resp:          &csi.NodeStageVolumeResponse{},
@@ -231,7 +232,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          "1000-stageOkToFormat",
 				StagingTargetPath: "/mnt/staging",
 				PublishContext: map[string]string{
-					"devicePath": "/dev/stageOkToFormat",
+					"devicePath": "/dev/sdf",
 				},
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -248,13 +249,83 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			expectFSCalls: func(m *mocks.MockFileSystem) {
 				m.EXPECT().Glob("/dev/sd*").Return([]string{"/dev/sda", "/dev/sdb"}, nil).AnyTimes()
-				m.EXPECT().Stat("/dev/disk/by-id/linode-stageOkToFormat").Return(nil, nil)
+				m.EXPECT().Stat("/dev/sdf").Return(nil, nil)
 			},
 			expectFormatCalls: func(m *mocks.MockFormater) {
-				m.EXPECT().FormatAndMount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FormatAndMount("/dev/sdf", "/mnt/staging", gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expectResizeFsCall: func(m *mocks.MockResizeFSer) {
-				m.EXPECT().NeedResize("/dev/disk/by-id/linode-stageOkToFormat", "/mnt/staging").Return(false, nil)
+				m.EXPECT().NeedResize("/dev/sdf", "/mnt/staging").Return(false, nil)
+			},
+			expectedError: nil,
+			resp:          &csi.NodeStageVolumeResponse{},
+		},
+		{
+			name: "stageUsesPublishContextDevicePath",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          "1000-stageUsesPublishContextDevicePath",
+				StagingTargetPath: "/mnt/staging",
+				PublishContext: map[string]string{
+					"devicePath": "/dev/sdg",
+				},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
+					},
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+			},
+			expectMounterCalls: func(m *mocks.MockMounter) {
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(false, nil).Times(1)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(1)
+			},
+			expectFSCalls: func(m *mocks.MockFileSystem) {
+				m.EXPECT().Glob("/dev/sd*").Return([]string{"/dev/sda", "/dev/sdb"}, nil).AnyTimes()
+				m.EXPECT().Stat("/dev/sdg").Return(nil, nil)
+			},
+			expectFormatCalls: func(m *mocks.MockFormater) {
+				m.EXPECT().FormatAndMount("/dev/sdg", "/mnt/staging", gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expectResizeFsCall: func(m *mocks.MockResizeFSer) {
+				m.EXPECT().NeedResize("/dev/sdg", "/mnt/staging").Return(false, nil)
+			},
+			expectedError: nil,
+			resp:          &csi.NodeStageVolumeResponse{},
+		},
+		{
+			name: "stageFallsBackWhenPublishContextDevicePathMissingOnNode",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          "1000-stageFallsBackWhenPublishContextDevicePathMissingOnNode",
+				StagingTargetPath: "/mnt/staging",
+				PublishContext: map[string]string{
+					"devicePath": "/dev/sdz",
+				},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
+					},
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+			},
+			expectMounterCalls: func(m *mocks.MockMounter) {
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(false, nil).Times(1)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(1)
+			},
+			expectFSCalls: func(m *mocks.MockFileSystem) {
+				m.EXPECT().Glob("/dev/sd*").Return([]string{"/dev/sda", "/dev/sdb"}, nil).AnyTimes()
+				m.EXPECT().Stat("/dev/sdz").Return(nil, os.ErrNotExist)
+				m.EXPECT().IsNotExist(os.ErrNotExist).Return(true)
+				m.EXPECT().Stat("/dev/disk/by-id/linode-stageFallsBackWhenPublishContext").Return(nil, nil)
+			},
+			expectFormatCalls: func(m *mocks.MockFormater) {
+				m.EXPECT().FormatAndMount("/dev/disk/by-id/linode-stageFallsBackWhenPublishContext", "/mnt/staging", gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expectResizeFsCall: func(m *mocks.MockResizeFSer) {
+				m.EXPECT().NeedResize("/dev/disk/by-id/linode-stageFallsBackWhenPublishContext", "/mnt/staging").Return(false, nil)
 			},
 			expectedError: nil,
 			resp:          &csi.NodeStageVolumeResponse{},
@@ -265,7 +336,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          "1000-stageOkToFormatAndResize",
 				StagingTargetPath: "/mnt/staging",
 				PublishContext: map[string]string{
-					"devicePath": "/dev/stageOkToFormatAndResize",
+					"devicePath": "/dev/sdh",
 				},
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -282,14 +353,14 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			expectFSCalls: func(m *mocks.MockFileSystem) {
 				m.EXPECT().Glob("/dev/sd*").Return([]string{"/dev/sda", "/dev/sdb"}, nil).AnyTimes()
-				m.EXPECT().Stat("/dev/disk/by-id/linode-stageOkToFormatAndResize").Return(nil, nil)
+				m.EXPECT().Stat("/dev/sdh").Return(nil, nil)
 			},
 			expectFormatCalls: func(m *mocks.MockFormater) {
-				m.EXPECT().FormatAndMount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FormatAndMount("/dev/sdh", "/mnt/staging", gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expectResizeFsCall: func(m *mocks.MockResizeFSer) {
-				m.EXPECT().NeedResize("/dev/disk/by-id/linode-stageOkToFormatAndResize", "/mnt/staging").Return(true, nil)
-				m.EXPECT().Resize("/dev/disk/by-id/linode-stageOkToFormatAndResize", "/mnt/staging").Return(true, nil)
+				m.EXPECT().NeedResize("/dev/sdh", "/mnt/staging").Return(true, nil)
+				m.EXPECT().Resize("/dev/sdh", "/mnt/staging").Return(true, nil)
 			},
 			expectedError: nil,
 			resp:          &csi.NodeStageVolumeResponse{},
@@ -313,7 +384,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          "1000-stagePartition",
 				StagingTargetPath: "/mnt/staging",
 				PublishContext: map[string]string{
-					"devicePath": "/dev/stagePartition",
+					"devicePath": "/dev/sdi",
 				},
 				VolumeContext: map[string]string{
 					"partition": "1",
@@ -333,13 +404,13 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			expectFSCalls: func(m *mocks.MockFileSystem) {
 				m.EXPECT().Glob("/dev/sd*").Return([]string{"/dev/sda", "/dev/sdb"}, nil).AnyTimes()
-				m.EXPECT().Stat("/dev/disk/by-id/linode-stagePartition-part1").Return(nil, nil)
+				m.EXPECT().Stat("/dev/sdi").Return(nil, nil)
 			},
 			expectFormatCalls: func(m *mocks.MockFormater) {
-				m.EXPECT().FormatAndMount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FormatAndMount("/dev/sdi", "/mnt/staging", gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expectResizeFsCall: func(m *mocks.MockResizeFSer) {
-				m.EXPECT().NeedResize("/dev/disk/by-id/linode-stagePartition-part1", "/mnt/staging").Return(false, nil)
+				m.EXPECT().NeedResize("/dev/sdi", "/mnt/staging").Return(false, nil)
 			},
 			expectedError: nil,
 			resp:          &csi.NodeStageVolumeResponse{},


### PR DESCRIPTION
## Summary

This change updates `NodeStageVolume` to prefer the controller-provided `PublishContext.devicePath` when it exists on the current node, and to fall back to the existing by-id lookup when it does not.

It also adds targeted `NodeStageVolume` coverage for both the PublishContext-first path and the fallback path, using Linode-style  device paths.

## Why

Older volumes can carry a persisted CSI `volumeHandle` that reflects a historical label format, while the actual Linode volume label may differ. In that situation, node-side by-id resolution derived from the volume handle can fail even though the controller has already published the correct attached device path for the current node.

By checking `PublishContext.devicePath` first, `NodeStageVolume` can stage volumes using the device path returned by the controller during attach. If that device path is not present on the node, the code still falls back to the previous by-id lookup behavior.

That makes the staging path more resilient for older volumes with inconsistent label versus volume-handle history, without removing the existing fallback.

## Validation

- ran `make test`
