### PR TITLE
[ci] bump codecov-action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - run: make build
       - run: go test -cover ./... -coverprofile ./coverage.out
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage.out
           fail_ci_if_error: true


### PR DESCRIPTION
It appears that codecov had some issues with their previous version and according to the [release notes for v7.0.0](https://github.com/codecov/codecov-action/releases/tag/v7.0.0), there was a migration issue that forced them to delete their old account. This caused CI to start failing on our repo, so bumping the version to their latest stable.
 
Signed-off-by: Moshe Vayner <moshe@vayner.me>

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

