### PR TITLE
Improve ListVolumes pagination

### DIFF
--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -19,10 +19,6 @@ import (
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/observability"
 )
 
-// maxListVolumesResponseEntries keeps default responses below gRPC message
-// limits while allowing callers to request a different page size explicitly.
-const maxListVolumesResponseEntries = 500
-
 type ControllerServer struct {
 	driver   *LinodeDriver
 	client   linodeclient.LinodeClient
@@ -419,7 +415,7 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	if maxEntries == 0 {
 		// Keep responses bounded when accounts have more than 500 volumes. The
 		// sidecar follows next_token to retrieve the remaining cached entries.
-		maxEntries = maxListVolumesResponseEntries
+		maxEntries = linodeclient.DefaultListPageSize
 	}
 
 	nextToken := ""

--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -3,11 +3,12 @@ package driver
 import (
 	"context"
 	"errors"
-	"math"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/google/uuid"
 	"github.com/linode/linodego/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -18,10 +19,18 @@ import (
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/observability"
 )
 
+// maxListVolumesResponseEntries keeps default responses below gRPC message
+// limits while allowing callers to request a different page size explicitly.
+const maxListVolumesResponseEntries = 500
+
 type ControllerServer struct {
 	driver   *LinodeDriver
 	client   linodeclient.LinodeClient
 	metadata Metadata
+
+	volumeEntries     []*csi.ListVolumesResponse_Entry
+	volumeEntriesSeen map[string]int
+	listVolumesLock   sync.Mutex
 
 	csi.UnimplementedControllerServer
 }
@@ -47,9 +56,10 @@ func NewControllerServer(ctx context.Context, driver *LinodeDriver, client linod
 	}
 
 	cs := &ControllerServer{
-		driver:   driver,
-		client:   client,
-		metadata: metadata,
+		driver:            driver,
+		client:            client,
+		metadata:          metadata,
+		volumeEntriesSeen: make(map[string]int),
 	}
 
 	log.V(4).Info("ControllerServer created successfully")
@@ -362,51 +372,65 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 
 	log.V(2).Info("Processing request", "starting_token", req.GetStartingToken(), "max_entries", req.GetMaxEntries())
 
-	startingToken := req.GetStartingToken()
+	if req.GetMaxEntries() < 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"ListVolumes got max entries request %d; value must not be negative", req.GetMaxEntries())
+	}
+
+	var volumeEntries []*csi.ListVolumesResponse_Entry
+	if req.GetStartingToken() == "" {
+		listOpts := linodeclient.NewListOptions(0, "")
+		log.V(4).Info("Listing volumes", "list_opts", listOpts)
+		volumes, err := cs.client.ListVolumes(ctx, listOpts)
+		if err != nil {
+			return &csi.ListVolumesResponse{}, errInternal("list volumes: %v", err)
+		}
+
+		volumeEntries = make([]*csi.ListVolumesResponse_Entry, 0, len(volumes))
+		for volNum := range volumes {
+			csiVol, publishedNodeIds, volumeCondition := getVolumeResponse(&volumes[volNum])
+			volumeEntries = append(volumeEntries, &csi.ListVolumesResponse_Entry{
+				Volume: csiVol,
+				Status: &csi.ListVolumesResponse_VolumeStatus{
+					PublishedNodeIds: publishedNodeIds,
+					VolumeCondition:  volumeCondition,
+				},
+			})
+		}
+	}
+
+	cs.listVolumesLock.Lock()
+	defer cs.listVolumesLock.Unlock()
+
+	offsetLow := 0
+	if req.GetStartingToken() == "" {
+		cs.volumeEntries = volumeEntries
+		cs.volumeEntriesSeen = make(map[string]int)
+	} else {
+		var ok bool
+		offsetLow, ok = cs.volumeEntriesSeen[req.GetStartingToken()]
+		if !ok {
+			return nil, status.Errorf(codes.Aborted,
+				"ListVolumes error with invalid starting token: %s", req.GetStartingToken())
+		}
+	}
+
+	maxEntries := int(req.GetMaxEntries())
+	if maxEntries == 0 {
+		// Keep responses bounded when accounts have more than 500 volumes. The
+		// sidecar follows next_token to retrieve the remaining cached entries.
+		maxEntries = maxListVolumesResponseEntries
+	}
+
 	nextToken := ""
-
-	listOpts := linodego.NewListOptions(0, "")
-	if req.GetMaxEntries() > 0 {
-		listOpts.PageSize = int(req.GetMaxEntries())
+	offsetHigh := min(offsetLow+maxEntries, len(cs.volumeEntries))
+	if offsetHigh < len(cs.volumeEntries) {
+		nextToken = uuid.NewString()
+		cs.volumeEntriesSeen[nextToken] = offsetHigh
 	}
 
-	if startingToken != "" {
-		startingPage, errParse := strconv.ParseInt(startingToken, 10, 0)
-		if errParse != nil {
-			return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted,
-				"invalid starting token: %q", startingToken)
-		}
-
-		if startingPage < math.MinInt || startingPage > math.MaxInt {
-			return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted,
-				"starting token out of bounds: %q", startingToken)
-		}
-		listOpts.Page = int(startingPage)
-	}
-
-	// List all volumes
-	log.V(4).Info("Listing volumes", "list_opts", listOpts)
-	volumes, err := cs.client.ListVolumes(ctx, listOpts)
-	if err != nil {
-		return &csi.ListVolumesResponse{}, errInternal("list volumes: %v", err)
-	}
-
-	entries := make([]*csi.ListVolumesResponse_Entry, 0, len(volumes))
-	for volNum := range volumes {
-		csiVol, publishedNodeIds, volumeCondition := getVolumeResponse(&volumes[volNum])
-		entries = append(entries, &csi.ListVolumesResponse_Entry{
-			Volume: csiVol,
-			Status: &csi.ListVolumesResponse_VolumeStatus{
-				PublishedNodeIds: publishedNodeIds,
-				VolumeCondition:  volumeCondition,
-			},
-		})
-	}
-
-	// Only set nextToken if we got a full page and there might be more
-	if req.GetMaxEntries() > 0 && len(volumes) >= listOpts.PageSize {
-		nextToken = strconv.Itoa(listOpts.Page + 1)
-	}
+	entries := make([]*csi.ListVolumesResponse_Entry, offsetHigh-offsetLow)
+	copy(entries, cs.volumeEntries[offsetLow:offsetHigh])
 
 	resp := &csi.ListVolumesResponse{
 		Entries:   entries,

--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -30,7 +30,6 @@ type ControllerServer struct {
 
 	volumeEntries     []*csi.ListVolumesResponse_Entry
 	volumeEntriesSeen map[string]int
-	volumeEntryTokens map[int]string
 	listVolumesLock   sync.Mutex
 
 	csi.UnimplementedControllerServer
@@ -61,7 +60,6 @@ func NewControllerServer(ctx context.Context, driver *LinodeDriver, client linod
 		client:            client,
 		metadata:          metadata,
 		volumeEntriesSeen: make(map[string]int),
-		volumeEntryTokens: make(map[int]string),
 	}
 
 	log.V(4).Info("ControllerServer created successfully")
@@ -408,7 +406,6 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	if req.GetStartingToken() == "" {
 		cs.volumeEntries = volumeEntries
 		cs.volumeEntriesSeen = make(map[string]int)
-		cs.volumeEntryTokens = make(map[int]string)
 	} else {
 		var ok bool
 		offsetLow, ok = cs.volumeEntriesSeen[req.GetStartingToken()]
@@ -428,13 +425,8 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	nextToken := ""
 	offsetHigh := min(offsetLow+maxEntries, len(cs.volumeEntries))
 	if offsetHigh < len(cs.volumeEntries) {
-		var ok bool
-		nextToken, ok = cs.volumeEntryTokens[offsetHigh]
-		if !ok {
-			nextToken = uuid.NewString()
-			cs.volumeEntriesSeen[nextToken] = offsetHigh
-			cs.volumeEntryTokens[offsetHigh] = nextToken
-		}
+		nextToken = uuid.NewString()
+		cs.volumeEntriesSeen[nextToken] = offsetHigh
 	}
 
 	entries := make([]*csi.ListVolumesResponse_Entry, offsetHigh-offsetLow)

--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -30,6 +30,7 @@ type ControllerServer struct {
 
 	volumeEntries     []*csi.ListVolumesResponse_Entry
 	volumeEntriesSeen map[string]int
+	volumeEntryTokens map[int]string
 	listVolumesLock   sync.Mutex
 
 	csi.UnimplementedControllerServer
@@ -60,6 +61,7 @@ func NewControllerServer(ctx context.Context, driver *LinodeDriver, client linod
 		client:            client,
 		metadata:          metadata,
 		volumeEntriesSeen: make(map[string]int),
+		volumeEntryTokens: make(map[int]string),
 	}
 
 	log.V(4).Info("ControllerServer created successfully")
@@ -406,12 +408,13 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	if req.GetStartingToken() == "" {
 		cs.volumeEntries = volumeEntries
 		cs.volumeEntriesSeen = make(map[string]int)
+		cs.volumeEntryTokens = make(map[int]string)
 	} else {
 		var ok bool
 		offsetLow, ok = cs.volumeEntriesSeen[req.GetStartingToken()]
 		if !ok {
 			return nil, status.Errorf(codes.Aborted,
-				"ListVolumes error with invalid starting token: %s", req.GetStartingToken())
+				"ListVolumes error with invalid starting token: %q", req.GetStartingToken())
 		}
 	}
 
@@ -425,8 +428,13 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	nextToken := ""
 	offsetHigh := min(offsetLow+maxEntries, len(cs.volumeEntries))
 	if offsetHigh < len(cs.volumeEntries) {
-		nextToken = uuid.NewString()
-		cs.volumeEntriesSeen[nextToken] = offsetHigh
+		var ok bool
+		nextToken, ok = cs.volumeEntryTokens[offsetHigh]
+		if !ok {
+			nextToken = uuid.NewString()
+			cs.volumeEntriesSeen[nextToken] = offsetHigh
+			cs.volumeEntryTokens[offsetHigh] = nextToken
+		}
 	}
 
 	entries := make([]*csi.ListVolumesResponse_Entry, offsetHigh-offsetLow)

--- a/internal/driver/controllerserver_helper.go
+++ b/internal/driver/controllerserver_helper.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	linodeclient "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-client"
 	linodevolumes "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-volumes"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/logger"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/observability"
@@ -110,7 +111,7 @@ func (cs *ControllerServer) canAttach(ctx context.Context, instance *linodego.In
 	}
 
 	// List the volumes currently attached to the instance
-	volumes, err := cs.client.ListInstanceVolumes(ctx, instance.ID, nil)
+	volumes, err := cs.client.ListInstanceVolumes(ctx, instance.ID, linodeclient.NewListOptions(0, ""))
 	if err != nil {
 		return false, errInternal("list instance volumes: %v", err)
 	}
@@ -135,7 +136,7 @@ func (cs *ControllerServer) maxAllowedVolumeAttachments(ctx context.Context, ins
 	}
 
 	// Retrieve the list of disks currently attached to the instance
-	disks, err := cs.client.ListInstanceDisks(ctx, instance.ID, nil)
+	disks, err := cs.client.ListInstanceDisks(ctx, instance.ID, linodeclient.NewListOptions(0, ""))
 	if err != nil {
 		return 0, errInternal("list instance disks: %v", err)
 	}
@@ -220,7 +221,7 @@ func (cs *ControllerServer) attemptCreateLinodeVolume(ctx context.Context, label
 		return nil, errInternal("marshal json filter: %v", err)
 	}
 
-	volumes, err := cs.client.ListVolumes(ctx, linodego.NewListOptions(0, string(jsonFilter)))
+	volumes, err := cs.client.ListVolumes(ctx, linodeclient.NewListOptions(0, string(jsonFilter)))
 	if err != nil {
 		return nil, errInternal("list volumes: %v", err)
 	}

--- a/internal/driver/controllerserver_test.go
+++ b/internal/driver/controllerserver_test.go
@@ -548,22 +548,6 @@ func TestListVolumesPagination(t *testing.T) {
 	}
 }
 
-func TestListVolumesZeroMaxEntriesUsesDefaultPageSize(t *testing.T) {
-	client := &fakeLinodeClient{volumes: makeTestVolumes(maxListVolumesResponseEntries + 1)}
-	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
-
-	resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := len(resp.GetEntries()); got != maxListVolumesResponseEntries {
-		t.Fatalf("entries = %d, want %d", got, maxListVolumesResponseEntries)
-	}
-	if resp.GetNextToken() == "" {
-		t.Fatal("expected a continuation token")
-	}
-}
-
 func TestListVolumesUsesAbsoluteOffsets(t *testing.T) {
 	client := &fakeLinodeClient{volumes: makeTestVolumes(5)}
 	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
@@ -593,24 +577,48 @@ func TestListVolumesUsesAbsoluteOffsets(t *testing.T) {
 	}
 }
 
-func TestListVolumesInvalidArgumentsAndTokens(t *testing.T) {
-	client := &fakeLinodeClient{volumes: makeTestVolumes(3)}
-	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+func TestListVolumesErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		request       *csi.ListVolumesRequest
+		providerError bool
+		wantCode      codes.Code
+		wantCalls     int
+	}{
+		{
+			name:      "negative max entries",
+			request:   &csi.ListVolumesRequest{MaxEntries: -1},
+			wantCode:  codes.InvalidArgument,
+			wantCalls: 0,
+		},
+		{
+			name:      "unknown token",
+			request:   &csi.ListVolumesRequest{StartingToken: "unknown"},
+			wantCode:  codes.Aborted,
+			wantCalls: 0,
+		},
+		{
+			name:          "provider error",
+			request:       &csi.ListVolumesRequest{},
+			providerError: true,
+			wantCode:      codes.Internal,
+			wantCalls:     1,
+		},
+	}
 
-	_, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: -1})
-	if status.Code(err) != codes.InvalidArgument {
-		t.Fatalf("negative max entries error = %v, want InvalidArgument", err)
-	}
-	if client.listVolumeCalls() != 0 {
-		t.Fatalf("provider calls = %d, want 0", client.listVolumeCalls())
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeLinodeClient{volumes: makeTestVolumes(3), throwErr: tt.providerError}
+			cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
 
-	_, err = cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{StartingToken: "unknown"})
-	if status.Code(err) != codes.Aborted {
-		t.Fatalf("unknown token error = %v, want Aborted", err)
-	}
-	if client.listVolumeCalls() != 0 {
-		t.Fatalf("provider calls = %d, want 0", client.listVolumeCalls())
+			_, err := cs.ListVolumes(context.Background(), tt.request)
+			if got := status.Code(err); got != tt.wantCode {
+				t.Fatalf("error code = %v, want %v: %v", got, tt.wantCode, err)
+			}
+			if got := client.listVolumeCalls(); got != tt.wantCalls {
+				t.Fatalf("provider calls = %d, want %d", got, tt.wantCalls)
+			}
+		})
 	}
 }
 
@@ -664,13 +672,6 @@ func TestListVolumesResponse(t *testing.T) {
 	}
 	if entry.GetStatus().GetVolumeCondition().GetAbnormal() {
 		t.Fatal("active volume reported as abnormal")
-	}
-}
-
-func TestListVolumesProviderError(t *testing.T) {
-	cs := &ControllerServer{client: &fakeLinodeClient{throwErr: true}, volumeEntriesSeen: make(map[string]int)}
-	if _, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{}); err == nil {
-		t.Fatal("expected provider error")
 	}
 }
 

--- a/internal/driver/controllerserver_test.go
+++ b/internal/driver/controllerserver_test.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/linode/linodego/v2"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/linode/linode-blockstorage-csi-driver/mocks"
 	linodeclient "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-client"
@@ -486,172 +489,264 @@ func TestControllerExpandVolume(t *testing.T) {
 	}
 }
 
-//nolint:gocognit // As simple as possible.
-func TestListVolumes(t *testing.T) {
-	cases := map[string]struct {
-		volumes  []linodego.Volume
-		throwErr bool
+func TestListVolumesPagination(t *testing.T) {
+	tests := []struct {
+		name            string
+		volumeCount     int
+		maxEntries      int32
+		expectedEntries []int
 	}{
-		"volume attached to node": {
-			volumes: []linodego.Volume{
-				{
-					ID:       1,
-					Label:    "foo",
-					Region:   "danmaaag",
-					Size:     30,
-					LinodeID: createLinodeID(10),
-					Status:   linodego.VolumeActive,
-				},
-			},
-		},
-		"volume not attached": {
-			volumes: []linodego.Volume{
-				{
-					ID:     1,
-					Label:  "bar",
-					Size:   30,
-					Status: linodego.VolumeActive,
-				},
-			},
-		},
-		"multiple volumes - with attachments": {
-			volumes: []linodego.Volume{
-				{
-					ID:       1,
-					Label:    "foo",
-					Size:     30,
-					LinodeID: createLinodeID(5),
-					Status:   linodego.VolumeActive,
-				},
-				{
-					ID:       2,
-					Label:    "foo",
-					Size:     60,
-					LinodeID: createLinodeID(10),
-					Status:   linodego.VolumeActive,
-				},
-			},
-		},
-		"multiple volumes - mixed attachments": {
-			volumes: []linodego.Volume{
-				{
-					ID:       1,
-					Label:    "foo",
-					Size:     30,
-					LinodeID: createLinodeID(5),
-					Status:   linodego.VolumeActive,
-				},
-				{
-					ID:     2,
-					Label:  "foo",
-					Size:   30,
-					Status: linodego.VolumeActive,
-				},
-			},
-		},
-		"Linode API error": {
-			throwErr: true,
-		},
+		{name: "no pagination", volumeCount: 325, maxEntries: 500, expectedEntries: []int{325}},
+		{name: "implicit pagination", volumeCount: 1327, expectedEntries: []int{500, 500, 327}},
+		{name: "explicit pagination", volumeCount: 723, maxEntries: 200, expectedEntries: []int{200, 200, 200, 123}},
+		{name: "exact boundary", volumeCount: 400, maxEntries: 200, expectedEntries: []int{200, 200}},
 	}
 
-	for c, tt := range cases {
-		t.Run(c, func(t *testing.T) {
-			cs := &ControllerServer{
-				client: &fakeLinodeClient{
-					volumes:  tt.volumes,
-					throwErr: tt.throwErr,
-				},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeLinodeClient{volumes: makeTestVolumes(tt.volumeCount)}
+			cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+			token := ""
+			seen := 0
+
+			for page, expected := range tt.expectedEntries {
+				resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{
+					MaxEntries:    tt.maxEntries,
+					StartingToken: token,
+				})
+				if err != nil {
+					t.Fatalf("page %d: %v", page+1, err)
+				}
+				if got := len(resp.GetEntries()); got != expected {
+					t.Fatalf("page %d entries = %d, want %d", page+1, got, expected)
+				}
+				for _, entry := range resp.GetEntries() {
+					key := linodevolumes.CreateLinodeVolumeKey(seen+1, fmt.Sprintf("volume-%d", seen+1))
+					want := key.GetVolumeKey()
+					if got := entry.GetVolume().GetVolumeId(); got != want {
+						t.Fatalf("entry %d volume ID = %q, want %q", seen, got, want)
+					}
+					seen++
+				}
+				token = resp.GetNextToken()
 			}
 
-			resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{StartingToken: "10"})
-			switch {
-			case (err != nil && !tt.throwErr):
-				t.Fatal("failed to list volumes:", err)
-			case (err != nil && tt.throwErr):
-				// expected failure
-			case (err == nil && tt.throwErr):
-				t.Fatal("should have failed to list volumes")
+			if token != "" {
+				t.Fatalf("expected pagination to finish, got token %q", token)
 			}
-
-			for _, entry := range resp.GetEntries() {
-				volume := entry.GetVolume()
-				if volume == nil {
-					t.Error("nil volume")
-					continue
-				}
-
-				var linodeVolume *linodego.Volume
-				for _, v := range tt.volumes {
-					key := linodevolumes.CreateLinodeVolumeKey(v.ID, v.Label)
-					if volume.GetVolumeId() == key.GetVolumeKey() {
-						v := v
-						linodeVolume = &v
-						break
-					}
-				}
-				if linodeVolume == nil {
-					t.Fatalf("no matching linode volume for %#v", volume)
-					return
-				}
-
-				if want, got := int64(linodeVolume.Size<<30), volume.GetCapacityBytes(); want != got {
-					t.Errorf("mismatched volume size: want=%d got=%d", want, got)
-				}
-				for _, topology := range volume.GetAccessibleTopology() {
-					region, ok := topology.GetSegments()[VolumeTopologyRegion]
-					if !ok {
-						t.Error("region not set in volume topology")
-					}
-					if region != linodeVolume.Region {
-						t.Errorf("mismatched regions: want=%q got=%q", linodeVolume.Region, region)
-					}
-				}
-
-				status := entry.GetStatus()
-				if status == nil {
-					t.Error("nil status")
-					continue
-				}
-				if status.GetVolumeCondition().GetAbnormal() {
-					t.Error("abnormal volume condition")
-				}
-
-				if n := len(status.GetPublishedNodeIds()); n > 1 {
-					t.Errorf("volume published to too many nodes (%d)", n)
-				}
-
-				switch publishedNodes := status.GetPublishedNodeIds(); {
-				case len(publishedNodes) == 0 && linodeVolume.LinodeID == nil:
-				// This case is fine - having it here prevents a segfault if we try to index into publishedNodes in the last case
-				case len(publishedNodes) == 0 && linodeVolume.LinodeID != nil:
-					t.Errorf("expected volume to be attached, got: %s, want: %d", status.GetPublishedNodeIds(), *linodeVolume.LinodeID)
-				case len(publishedNodes) != 0 && linodeVolume.LinodeID == nil:
-					t.Errorf("expected volume to be unattached, got: %s", publishedNodes)
-				case publishedNodes[0] != fmt.Sprintf("%d", *linodeVolume.LinodeID):
-					t.Fatalf("got: %s, want: %d published node id", status.GetPublishedNodeIds()[0], *linodeVolume.LinodeID)
-				}
+			if seen != tt.volumeCount {
+				t.Fatalf("saw %d volumes, want %d", seen, tt.volumeCount)
+			}
+			if client.listVolumeCalls() != 1 {
+				t.Fatalf("provider calls = %d, want 1", client.listVolumeCalls())
+			}
+			if client.listOptions == nil || client.listOptions.Page != 0 || client.listOptions.PageSize != linodeclient.DefaultListPageSize {
+				t.Fatalf("unexpected provider list options: %#v", client.listOptions)
 			}
 		})
 	}
 }
 
+func TestListVolumesZeroMaxEntriesUsesDefaultPageSize(t *testing.T) {
+	client := &fakeLinodeClient{volumes: makeTestVolumes(maxListVolumesResponseEntries + 1)}
+	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+
+	resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.GetEntries()); got != maxListVolumesResponseEntries {
+		t.Fatalf("entries = %d, want %d", got, maxListVolumesResponseEntries)
+	}
+	if resp.GetNextToken() == "" {
+		t.Fatal("expected a continuation token")
+	}
+}
+
+func TestListVolumesUsesAbsoluteOffsets(t *testing.T) {
+	client := &fakeLinodeClient{volumes: makeTestVolumes(5)}
+	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+
+	first, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{
+		MaxEntries:    3,
+		StartingToken: first.GetNextToken(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(second.GetEntries()); got != 3 {
+		t.Fatalf("second page entries = %d, want 3", got)
+	}
+	if got := second.GetEntries()[0].GetVolume().GetVolumeId(); got != "3-volume-3" {
+		t.Fatalf("second page starts with %q, want %q", got, "3-volume-3")
+	}
+	if second.GetNextToken() != "" {
+		t.Fatalf("expected final page, got token %q", second.GetNextToken())
+	}
+	if client.listVolumeCalls() != 1 {
+		t.Fatalf("provider calls = %d, want 1", client.listVolumeCalls())
+	}
+}
+
+func TestListVolumesInvalidArgumentsAndTokens(t *testing.T) {
+	client := &fakeLinodeClient{volumes: makeTestVolumes(3)}
+	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+
+	_, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: -1})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("negative max entries error = %v, want InvalidArgument", err)
+	}
+	if client.listVolumeCalls() != 0 {
+		t.Fatalf("provider calls = %d, want 0", client.listVolumeCalls())
+	}
+
+	_, err = cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{StartingToken: "unknown"})
+	if status.Code(err) != codes.Aborted {
+		t.Fatalf("unknown token error = %v, want Aborted", err)
+	}
+	if client.listVolumeCalls() != 0 {
+		t.Fatalf("provider calls = %d, want 0", client.listVolumeCalls())
+	}
+}
+
+func TestListVolumesNewTraversalInvalidatesTokens(t *testing.T) {
+	client := &fakeLinodeClient{volumes: makeTestVolumes(3)}
+	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+
+	first, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: 1}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{
+		MaxEntries:    1,
+		StartingToken: first.GetNextToken(),
+	})
+	if status.Code(err) != codes.Aborted {
+		t.Fatalf("stale token error = %v, want Aborted", err)
+	}
+	if client.listVolumeCalls() != 2 {
+		t.Fatalf("provider calls = %d, want 2", client.listVolumeCalls())
+	}
+}
+
+func TestListVolumesResponse(t *testing.T) {
+	client := &fakeLinodeClient{volumes: []linodego.Volume{{
+		ID:       1,
+		Label:    "foo",
+		Region:   "us-east",
+		Size:     30,
+		LinodeID: createLinodeID(10),
+		Status:   linodego.VolumeActive,
+	}}}
+	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+
+	resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := resp.GetEntries()[0]
+	if got := entry.GetVolume().GetCapacityBytes(); got != 30<<30 {
+		t.Fatalf("capacity = %d, want %d", got, int64(30<<30))
+	}
+	if got := entry.GetVolume().GetAccessibleTopology()[0].GetSegments()[VolumeTopologyRegion]; got != "us-east" {
+		t.Fatalf("region = %q, want us-east", got)
+	}
+	if got := entry.GetStatus().GetPublishedNodeIds(); !reflect.DeepEqual(got, []string{"10"}) {
+		t.Fatalf("published nodes = %v, want [10]", got)
+	}
+	if entry.GetStatus().GetVolumeCondition().GetAbnormal() {
+		t.Fatal("active volume reported as abnormal")
+	}
+}
+
+func TestListVolumesProviderError(t *testing.T) {
+	cs := &ControllerServer{client: &fakeLinodeClient{throwErr: true}, volumeEntriesSeen: make(map[string]int)}
+	if _, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{}); err == nil {
+		t.Fatal("expected provider error")
+	}
+}
+
+func TestListVolumesConcurrent(t *testing.T) {
+	client := &fakeLinodeClient{volumes: makeTestVolumes(50)}
+	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: 10})
+			if err != nil {
+				t.Errorf("first page: %v", err)
+				return
+			}
+			_, err = cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{
+				MaxEntries:    10,
+				StartingToken: resp.GetNextToken(),
+			})
+			if err != nil && status.Code(err) != codes.Aborted {
+				t.Errorf("second page: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func makeTestVolumes(count int) []linodego.Volume {
+	volumes := make([]linodego.Volume, count)
+	for i := range count {
+		volumes[i] = linodego.Volume{
+			ID:     i + 1,
+			Label:  fmt.Sprintf("volume-%d", i+1),
+			Size:   10,
+			Status: linodego.VolumeActive,
+		}
+	}
+	return volumes
+}
+
 var _ linodeclient.LinodeClient = &fakeLinodeClient{}
 
 type fakeLinodeClient struct {
-	volumes  []linodego.Volume
-	disks    []linodego.InstanceDisk
-	throwErr bool
+	mu          sync.Mutex
+	volumes     []linodego.Volume
+	disks       []linodego.InstanceDisk
+	throwErr    bool
+	listCalls   int
+	listOptions *linodego.ListOptions
 }
 
 func (flc *fakeLinodeClient) ListInstances(context.Context, *linodego.ListOptions) ([]linodego.Instance, error) {
 	return nil, nil
 }
 
-func (flc *fakeLinodeClient) ListVolumes(context.Context, *linodego.ListOptions) ([]linodego.Volume, error) {
+func (flc *fakeLinodeClient) ListVolumes(_ context.Context, options *linodego.ListOptions) ([]linodego.Volume, error) {
+	flc.mu.Lock()
+	flc.listCalls++
+	if options != nil {
+		copy := *options
+		flc.listOptions = &copy
+	}
+	flc.mu.Unlock()
+
 	if flc.throwErr {
 		return nil, errors.New("sad times mate")
 	}
 	return flc.volumes, nil
+}
+
+func (flc *fakeLinodeClient) listVolumeCalls() int {
+	flc.mu.Lock()
+	defer flc.mu.Unlock()
+	return flc.listCalls
 }
 
 func (c *fakeLinodeClient) ListInstanceVolumes(_ context.Context, _ int, _ *linodego.ListOptions) ([]linodego.Volume, error) {

--- a/internal/driver/controllerserver_test.go
+++ b/internal/driver/controllerserver_test.go
@@ -489,6 +489,7 @@ func TestControllerExpandVolume(t *testing.T) {
 	}
 }
 
+//nolint:gocognit // The table-driven pagination assertions are clearer in one test.
 func TestListVolumesPagination(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -732,8 +733,8 @@ func (flc *fakeLinodeClient) ListVolumes(_ context.Context, options *linodego.Li
 	flc.mu.Lock()
 	flc.listCalls++
 	if options != nil {
-		copy := *options
-		flc.listOptions = &copy
+		optionsCopy := *options
+		flc.listOptions = &optionsCopy
 	}
 	flc.mu.Unlock()
 

--- a/internal/driver/controllerserver_test.go
+++ b/internal/driver/controllerserver_test.go
@@ -577,12 +577,45 @@ func TestListVolumesUsesAbsoluteOffsets(t *testing.T) {
 	}
 }
 
+func TestListVolumesRetryReusesNextToken(t *testing.T) {
+	client := &fakeLinodeClient{volumes: makeTestVolumes(5)}
+	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
+
+	first, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := &csi.ListVolumesRequest{MaxEntries: 1, StartingToken: first.GetNextToken()}
+	second, err := cs.ListVolumes(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retry, err := cs.ListVolumes(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if retry.GetNextToken() != second.GetNextToken() {
+		t.Fatalf("retry token = %q, want %q", retry.GetNextToken(), second.GetNextToken())
+	}
+	if got := retry.GetEntries()[0].GetVolume().GetVolumeId(); got != second.GetEntries()[0].GetVolume().GetVolumeId() {
+		t.Fatalf("retry entry = %q, want %q", got, second.GetEntries()[0].GetVolume().GetVolumeId())
+	}
+	if got := len(cs.volumeEntriesSeen); got != 2 {
+		t.Fatalf("stored tokens = %d, want 2", got)
+	}
+	if got := client.listVolumeCalls(); got != 1 {
+		t.Fatalf("provider calls = %d, want 1", got)
+	}
+}
+
 func TestListVolumesErrors(t *testing.T) {
 	tests := []struct {
 		name          string
 		request       *csi.ListVolumesRequest
 		providerError bool
 		wantCode      codes.Code
+		wantMessage   string
 		wantCalls     int
 	}{
 		{
@@ -592,10 +625,11 @@ func TestListVolumesErrors(t *testing.T) {
 			wantCalls: 0,
 		},
 		{
-			name:      "unknown token",
-			request:   &csi.ListVolumesRequest{StartingToken: "unknown"},
-			wantCode:  codes.Aborted,
-			wantCalls: 0,
+			name:        "unknown token",
+			request:     &csi.ListVolumesRequest{StartingToken: "unknown\ntoken"},
+			wantCode:    codes.Aborted,
+			wantMessage: `ListVolumes error with invalid starting token: "unknown\ntoken"`,
+			wantCalls:   0,
 		},
 		{
 			name:          "provider error",
@@ -614,6 +648,9 @@ func TestListVolumesErrors(t *testing.T) {
 			_, err := cs.ListVolumes(context.Background(), tt.request)
 			if got := status.Code(err); got != tt.wantCode {
 				t.Fatalf("error code = %v, want %v: %v", got, tt.wantCode, err)
+			}
+			if tt.wantMessage != "" && status.Convert(err).Message() != tt.wantMessage {
+				t.Fatalf("error message = %q, want %q", status.Convert(err).Message(), tt.wantMessage)
 			}
 			if got := client.listVolumeCalls(); got != tt.wantCalls {
 				t.Fatalf("provider calls = %d, want %d", got, tt.wantCalls)

--- a/internal/driver/controllerserver_test.go
+++ b/internal/driver/controllerserver_test.go
@@ -577,38 +577,6 @@ func TestListVolumesUsesAbsoluteOffsets(t *testing.T) {
 	}
 }
 
-func TestListVolumesRetryReusesNextToken(t *testing.T) {
-	client := &fakeLinodeClient{volumes: makeTestVolumes(5)}
-	cs := &ControllerServer{client: client, volumeEntriesSeen: make(map[string]int)}
-
-	first, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{MaxEntries: 1})
-	if err != nil {
-		t.Fatal(err)
-	}
-	request := &csi.ListVolumesRequest{MaxEntries: 1, StartingToken: first.GetNextToken()}
-	second, err := cs.ListVolumes(context.Background(), request)
-	if err != nil {
-		t.Fatal(err)
-	}
-	retry, err := cs.ListVolumes(context.Background(), request)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if retry.GetNextToken() != second.GetNextToken() {
-		t.Fatalf("retry token = %q, want %q", retry.GetNextToken(), second.GetNextToken())
-	}
-	if got := retry.GetEntries()[0].GetVolume().GetVolumeId(); got != second.GetEntries()[0].GetVolume().GetVolumeId() {
-		t.Fatalf("retry entry = %q, want %q", got, second.GetEntries()[0].GetVolume().GetVolumeId())
-	}
-	if got := len(cs.volumeEntriesSeen); got != 2 {
-		t.Fatalf("stored tokens = %d, want 2", got)
-	}
-	if got := client.listVolumeCalls(); got != 1 {
-		t.Fatalf("provider calls = %d, want 1", got)
-	}
-}
-
 func TestListVolumesErrors(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/linode-client/linode_client.go
+++ b/pkg/linode-client/linode_client.go
@@ -6,6 +6,16 @@ import (
 	"github.com/linode/linodego/v2"
 )
 
+// DefaultListPageSize is the page size used for internal Linode list requests.
+const DefaultListPageSize = 500
+
+// NewListOptions creates list options with the driver's standard page size.
+func NewListOptions(page int, filter string) *linodego.ListOptions {
+	options := linodego.NewListOptions(page, filter)
+	options.PageSize = DefaultListPageSize
+	return options
+}
+
 type LinodeClient interface {
 	ListInstances(context.Context, *linodego.ListOptions) ([]linodego.Instance, error) // Needed for metadata
 	ListVolumes(context.Context, *linodego.ListOptions) ([]linodego.Volume, error)

--- a/pkg/linode-client/linode_client_test.go
+++ b/pkg/linode-client/linode_client_test.go
@@ -6,6 +6,20 @@ import (
 	"github.com/linode/linodego/v2"
 )
 
+func TestNewListOptions(t *testing.T) {
+	options := NewListOptions(2, `{"label":"example"}`)
+
+	if options.Page != 2 {
+		t.Fatalf("expected page 2, got %d", options.Page)
+	}
+	if options.PageSize != DefaultListPageSize {
+		t.Fatalf("expected page size %d, got %d", DefaultListPageSize, options.PageSize)
+	}
+	if options.Filter != `{"label":"example"}` {
+		t.Fatalf("expected filter to be preserved, got %q", options.Filter)
+	}
+}
+
 func TestNewLinodeClient(t *testing.T) {
 	type args struct {
 		token  string


### PR DESCRIPTION
## Summary

- fetch the complete Linode volume list only when `starting_token` is empty
- cache the resulting CSI entries for the current traversal and map opaque tokens to offsets
- serve continuation pages from memory to avoid repeated Linode API calls and inconsistent page boundaries
- use a 500-entry default response size to keep large responses bounded; the sidecar follows `next_token` until traversal completes
- use a 500-item Linode API page size while Linodego collects all provider pages

## Flow

```mermaid
sequenceDiagram
    participant Sidecar
    participant Driver as CSI driver
    participant API as Linode API

    Sidecar->>Driver: ListVolumes(starting_token="")
    Driver->>API: List all volumes (page size 500)
    API-->>Driver: Complete volume list
    Driver->>Driver: Build and cache CSI entries
    Driver->>Driver: Store T1 -> offset 500
    Driver-->>Sidecar: entries[0:500], next_token=T1

    Sidecar->>Driver: ListVolumes(starting_token=T1)
    Driver->>Driver: Read cached entries at offset 500
    Driver->>Driver: Store T2 -> offset 1000
    Driver-->>Sidecar: entries[500:1000], next_token=T2

    loop Until next_token is empty
        Sidecar->>Driver: ListVolumes(starting_token=next_token)
        Driver-->>Sidecar: Next cached page and next_token
    end
```

Each empty-token request starts a fresh traversal and replaces the cached snapshot. Continuation requests use the same snapshot, which keeps pagination stable while avoiding extra provider calls.
