### PR TITLE
Fix single-node single-writer publish validation

### DIFF
--- a/internal/driver/nodeserver.go
+++ b/internal/driver/nodeserver.go
@@ -105,6 +105,19 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, err
 	}
 
+	accessMode := req.GetVolumeCapability().GetAccessMode().GetMode()
+	if accessMode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER || accessMode == csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER {
+		publishedElsewhere, err := ns.isVolumePublishedElsewhere(req)
+		if err != nil {
+			observability.RecordMetrics(observability.NodePublishTotal, observability.NodePublishDuration, observability.Failed, functionStartTime)
+			return nil, errInternal("failed to check existing publications for volume %s: %v", volumeID, err)
+		}
+		if publishedElsewhere {
+			observability.RecordMetrics(observability.NodePublishTotal, observability.NodePublishDuration, observability.Failed, functionStartTime)
+			return nil, status.Errorf(codes.FailedPrecondition, "volume %s is already published at a different target path", volumeID)
+		}
+	}
+
 	// Set mount options
 	options := []string{bindMountOption}
 	if req.GetReadonly() {

--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -243,7 +243,8 @@ func (ns *NodeServer) isVolumePublishedElsewhere(req *csi.NodePublishVolumeReque
 		if err != nil {
 			return false, err
 		}
-		for _, mountPoint := range mountPoints {
+		for i := range mountPoints {
+			mountPoint := &mountPoints[i]
 			if filepath.Clean(mountPoint.Device) == devicePath && filepath.Clean(mountPoint.Path) != targetPath {
 				return true, nil
 			}

--- a/internal/driver/nodeserver_helpers.go
+++ b/internal/driver/nodeserver_helpers.go
@@ -234,6 +234,35 @@ func (ns *NodeServer) ensureMountPoint(ctx context.Context, path string, fs file
 	return notMnt, nil
 }
 
+func (ns *NodeServer) isVolumePublishedElsewhere(req *csi.NodePublishVolumeRequest) (bool, error) {
+	targetPath := filepath.Clean(req.GetTargetPath())
+
+	if req.GetVolumeCapability().GetBlock() != nil {
+		devicePath := filepath.Clean(req.GetPublishContext()[devicePathKey])
+		mountPoints, err := ns.mounter.List()
+		if err != nil {
+			return false, err
+		}
+		for _, mountPoint := range mountPoints {
+			if filepath.Clean(mountPoint.Device) == devicePath && filepath.Clean(mountPoint.Path) != targetPath {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	mountRefs, err := ns.mounter.GetMountRefs(req.GetStagingTargetPath())
+	if err != nil {
+		return false, err
+	}
+	for _, mountRef := range mountRefs {
+		if filepath.Clean(mountRef) != targetPath {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // nodePublishVolumeBlock handles the NodePublishVolume call for block volumes.
 //
 // It takes a CSI NodePublishVolumeRequest, a list of mount options, and a file system interface.

--- a/internal/driver/nodeserver_test.go
+++ b/internal/driver/nodeserver_test.go
@@ -68,6 +68,23 @@ func TestNodePublishVolume(t *testing.T) {
 			expectedError: status.Error(codes.FailedPrecondition, "volume vol-123 is already published at a different target path"),
 		},
 		{
+			name: "legacy single node writer already published elsewhere",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          "vol-123",
+				TargetPath:        "/mnt/target",
+				StagingTargetPath: "/mnt/staging",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+			expectMounterCalls: func(m *mocks.MockMounter) {
+				m.EXPECT().GetMountRefs("/mnt/staging").Return([]string{"/mnt/other-target"}, nil)
+			},
+			expectedError: status.Error(codes.FailedPrecondition, "volume vol-123 is already published at a different target path"),
+		},
+		{
 			name: "single node single writer idempotent publish",
 			req: &csi.NodePublishVolumeRequest{
 				VolumeId:          "vol-123",

--- a/internal/driver/nodeserver_test.go
+++ b/internal/driver/nodeserver_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jaypipes/ghw"
 	"github.com/jaypipes/ghw/pkg/block"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/exec"
 
@@ -48,6 +50,59 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			name: "single node single writer already published elsewhere",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          "vol-123",
+				TargetPath:        "/mnt/target",
+				StagingTargetPath: "/mnt/staging",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+					},
+				},
+			},
+			expectMounterCalls: func(m *mocks.MockMounter) {
+				m.EXPECT().GetMountRefs("/mnt/staging").Return([]string{"/mnt/other-target"}, nil)
+			},
+			expectedError: status.Error(codes.FailedPrecondition, "volume vol-123 is already published at a different target path"),
+		},
+		{
+			name: "single node single writer idempotent publish",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          "vol-123",
+				TargetPath:        "/mnt/target",
+				StagingTargetPath: "/mnt/staging",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+					},
+				},
+			},
+			resp: &csi.NodePublishVolumeResponse{},
+			expectMounterCalls: func(m *mocks.MockMounter) {
+				m.EXPECT().GetMountRefs("/mnt/staging").Return([]string{"/mnt/target"}, nil)
+				m.EXPECT().IsLikelyNotMountPoint("/mnt/target").Return(false, nil)
+			},
+		},
+		{
+			name: "single node multi writer publishes at another target",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          "vol-123",
+				TargetPath:        "/mnt/target",
+				StagingTargetPath: "/mnt/staging",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
+					},
+				},
+			},
+			resp: &csi.NodePublishVolumeResponse{},
+			expectMounterCalls: func(m *mocks.MockMounter) {
+				m.EXPECT().IsLikelyNotMountPoint("/mnt/target").Return(true, nil)
+				m.EXPECT().Mount("/mnt/staging", "/mnt/target", "ext4", []string{"bind"}).Return(nil)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -69,7 +124,7 @@ func TestNodePublishVolume(t *testing.T) {
 				},
 			}
 			returnedResp, err := ns.NodePublishVolume(context.Background(), tt.req)
-			if err != nil && !errors.Is(err, tt.expectedError) {
+			if status.Code(err) != status.Code(tt.expectedError) {
 				t.Errorf("NodePublishVolume error = %v, wantErr %v", err, tt.expectedError)
 			}
 			if !reflect.DeepEqual(returnedResp, tt.resp) {

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@ kubectl = "1.36.2"
 kustomize = "5.8.1"
 "go:github.com/kyverno/chainsaw" = "0.2.15"
 "go:github.com/golang/mock/mockgen" = "1.6.0"
-"go:github.com/kubernetes-csi/csi-test/v5/cmd/csi-sanity" = "5.4.0"
+"go:github.com/kubernetes-csi/csi-test/v5/cmd/csi-sanity" = "5.5.0"
 yq = "4.52.2"
 envsubst = "1.4.3"
 jq = "1.8.2"
@@ -67,4 +67,3 @@ run = "make upstream-e2e-tests"
 [tasks.csi-sanity-test]
 description = "Run CSI sanity tests"
 run = "make csi-sanity-test"
-


### PR DESCRIPTION
## Summary
- reject `NodePublishVolume` requests for `SINGLE_NODE_SINGLE_WRITER` and legacy `SINGLE_NODE_WRITER` when the volume is already published at a different target path
- preserve idempotent same-target publishes and allow different targets for `SINGLE_NODE_MULTI_WRITER`
- update CSI sanity from v5.4.0 to v5.5.0

## Why
CSI sanity v5.5.0 added coverage for the `SINGLE_NODE_MULTI_WRITER` node capability. The test `should fail when volume with single node single writer access mode is already mounted at a different target path` was failing because the driver created another bind mount instead of returning `FailedPrecondition`.

The new sanity coverage was added in [kubernetes-csi/csi-test#602](https://github.com/kubernetes-csi/csi-test/pull/602).

## Testing
- added focused unit coverage for rejected different-target single-writer publishes, same-target idempotency, and multi-writer publishes