### PR TITLE
[improvement] Set list page size to 500 for all linode API calls

### DIFF
--- a/internal/driver/controllerserver.go
+++ b/internal/driver/controllerserver.go
@@ -3,7 +3,6 @@ package driver
 import (
 	"context"
 	"errors"
-	"math"
 	"strconv"
 	"time"
 
@@ -351,9 +350,10 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 }
 
 // ListVolumes returns a list of all volumes known to the provider,
-// including their IDs, sizes, and accessibility information. It
-// supports pagination through the starting token and maximum entries
-// parameters as specified in the CSI Driver Spec.
+// including their IDs, sizes, and accessibility information. The starting
+// token is the 1-based page number to fetch; max_entries is intentionally
+// ignored, as pages are always sized to DefaultPageSize to bound the number
+// of Linode API requests.
 // For more details, refer to the CSI Driver Spec documentation.
 func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	log, ctx := logger.GetLogger(ctx)
@@ -365,23 +365,23 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	startingToken := req.GetStartingToken()
 	nextToken := ""
 
-	listOpts := linodego.NewListOptions(0, "")
-	if req.GetMaxEntries() > 0 {
-		listOpts.PageSize = int(req.GetMaxEntries())
-	}
+	// Page is 1-based; DefaultListOptions pins PageSize to the API max so a
+	// full page signals more results and a partial page ends pagination.
+	listOpts := linodeclient.DefaultListOptions(1, "")
 
 	if startingToken != "" {
-		startingPage, errParse := strconv.ParseInt(startingToken, 10, 0)
+		page, errParse := strconv.ParseInt(startingToken, 10, 0)
 		if errParse != nil {
 			return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted,
 				"invalid starting token: %q", startingToken)
 		}
 
-		if startingPage < math.MinInt || startingPage > math.MaxInt {
+		// linodego treats Page == 0 as "fetch all pages", so reject anything below 1.
+		if page < 1 {
 			return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted,
 				"starting token out of bounds: %q", startingToken)
 		}
-		listOpts.Page = int(startingPage)
+		listOpts.Page = int(page)
 	}
 
 	// List all volumes
@@ -404,7 +404,7 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	}
 
 	// Only set nextToken if we got a full page and there might be more
-	if req.GetMaxEntries() > 0 && len(volumes) >= listOpts.PageSize {
+	if len(volumes) >= linodeclient.DefaultPageSize {
 		nextToken = strconv.Itoa(listOpts.Page + 1)
 	}
 

--- a/internal/driver/controllerserver_helper.go
+++ b/internal/driver/controllerserver_helper.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	linodeclient "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-client"
 	linodevolumes "github.com/linode/linode-blockstorage-csi-driver/pkg/linode-volumes"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/logger"
 	"github.com/linode/linode-blockstorage-csi-driver/pkg/observability"
@@ -110,7 +111,7 @@ func (cs *ControllerServer) canAttach(ctx context.Context, instance *linodego.In
 	}
 
 	// List the volumes currently attached to the instance
-	volumes, err := cs.client.ListInstanceVolumes(ctx, instance.ID, nil)
+	volumes, err := cs.client.ListInstanceVolumes(ctx, instance.ID, linodeclient.DefaultListOptions(0, ""))
 	if err != nil {
 		return false, errInternal("list instance volumes: %v", err)
 	}
@@ -135,7 +136,7 @@ func (cs *ControllerServer) maxAllowedVolumeAttachments(ctx context.Context, ins
 	}
 
 	// Retrieve the list of disks currently attached to the instance
-	disks, err := cs.client.ListInstanceDisks(ctx, instance.ID, nil)
+	disks, err := cs.client.ListInstanceDisks(ctx, instance.ID, linodeclient.DefaultListOptions(0, ""))
 	if err != nil {
 		return 0, errInternal("list instance disks: %v", err)
 	}
@@ -220,7 +221,7 @@ func (cs *ControllerServer) attemptCreateLinodeVolume(ctx context.Context, label
 		return nil, errInternal("marshal json filter: %v", err)
 	}
 
-	volumes, err := cs.client.ListVolumes(ctx, linodego.NewListOptions(0, string(jsonFilter)))
+	volumes, err := cs.client.ListVolumes(ctx, linodeclient.DefaultListOptions(0, string(jsonFilter)))
 	if err != nil {
 		return nil, errInternal("list volumes: %v", err)
 	}

--- a/internal/driver/controllerserver_test.go
+++ b/internal/driver/controllerserver_test.go
@@ -563,7 +563,7 @@ func TestListVolumes(t *testing.T) {
 				},
 			}
 
-			resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{StartingToken: "10"})
+			resp, err := cs.ListVolumes(context.Background(), &csi.ListVolumesRequest{StartingToken: "1"})
 			switch {
 			case (err != nil && !tt.throwErr):
 				t.Fatal("failed to list volumes:", err)
@@ -635,19 +635,101 @@ func TestListVolumes(t *testing.T) {
 	}
 }
 
+func TestListVolumesPagination(t *testing.T) {
+	tests := []struct {
+		name              string
+		request           *csi.ListVolumesRequest
+		volumeCount       int
+		expectedPage      int
+		expectedNextToken string
+		expectErr         bool
+	}{
+		{
+			name:              "empty token starts first page",
+			request:           &csi.ListVolumesRequest{},
+			volumeCount:       linodeclient.DefaultPageSize,
+			expectedPage:      1,
+			expectedNextToken: "2",
+		},
+		{
+			name:              "max_entries is ignored",
+			request:           &csi.ListVolumesRequest{StartingToken: "1", MaxEntries: 10},
+			volumeCount:       linodeclient.DefaultPageSize,
+			expectedPage:      1,
+			expectedNextToken: "2",
+		},
+		{
+			name:         "token selects the requested page",
+			request:      &csi.ListVolumesRequest{StartingToken: "2"},
+			volumeCount:  1,
+			expectedPage: 2,
+		},
+		{
+			name:         "partial page ends pagination",
+			request:      &csi.ListVolumesRequest{StartingToken: "3"},
+			volumeCount:  linodeclient.DefaultPageSize - 1,
+			expectedPage: 3,
+		},
+		{
+			name:      "non-numeric token is rejected",
+			request:   &csi.ListVolumesRequest{StartingToken: "abc"},
+			expectErr: true,
+		},
+		{
+			name:      "zero token is rejected",
+			request:   &csi.ListVolumesRequest{StartingToken: "0"},
+			expectErr: true,
+		},
+		{
+			name:      "negative token is rejected",
+			request:   &csi.ListVolumesRequest{StartingToken: "-1"},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeLinodeClient{volumes: make([]linodego.Volume, test.volumeCount)}
+			cs := &ControllerServer{client: client}
+
+			response, err := cs.ListVolumes(context.Background(), test.request)
+			if test.expectErr {
+				if err == nil {
+					t.Fatal("ListVolumes() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ListVolumes() error = %v", err)
+			}
+			if client.listOptions.Page != test.expectedPage {
+				t.Errorf("page = %d, want %d", client.listOptions.Page, test.expectedPage)
+			}
+			if client.listOptions.PageSize != linodeclient.DefaultPageSize {
+				t.Errorf("page size = %d, want %d", client.listOptions.PageSize, linodeclient.DefaultPageSize)
+			}
+			if response.GetNextToken() != test.expectedNextToken {
+				t.Errorf("next token = %q, want %q", response.GetNextToken(), test.expectedNextToken)
+			}
+		})
+	}
+}
+
 var _ linodeclient.LinodeClient = &fakeLinodeClient{}
 
 type fakeLinodeClient struct {
-	volumes  []linodego.Volume
-	disks    []linodego.InstanceDisk
-	throwErr bool
+	volumes     []linodego.Volume
+	disks       []linodego.InstanceDisk
+	listOptions *linodego.ListOptions
+	throwErr    bool
 }
 
 func (flc *fakeLinodeClient) ListInstances(context.Context, *linodego.ListOptions) ([]linodego.Instance, error) {
 	return nil, nil
 }
 
-func (flc *fakeLinodeClient) ListVolumes(context.Context, *linodego.ListOptions) ([]linodego.Volume, error) {
+func (flc *fakeLinodeClient) ListVolumes(_ context.Context, options *linodego.ListOptions) ([]linodego.Volume, error) {
+	flc.listOptions = options
 	if flc.throwErr {
 		return nil, errors.New("sad times mate")
 	}

--- a/pkg/linode-client/linode_client.go
+++ b/pkg/linode-client/linode_client.go
@@ -6,6 +6,19 @@ import (
 	"github.com/linode/linodego/v2"
 )
 
+// DefaultPageSize is the page size used for all Linode API list calls.
+// 500 is the maximum page size allowed by the Linode API.
+const DefaultPageSize = 500
+
+// DefaultListOptions builds ListOptions for a Linode API list call with the
+// page size pinned to DefaultPageSize. Pass page 0 to fetch all pages, or a
+// 1-based page number to fetch a single page.
+func DefaultListOptions(page int, filter string) *linodego.ListOptions {
+	opts := linodego.NewListOptions(page, filter)
+	opts.PageSize = DefaultPageSize
+	return opts
+}
+
 type LinodeClient interface {
 	ListInstances(context.Context, *linodego.ListOptions) ([]linodego.Instance, error) // Needed for metadata
 	ListVolumes(context.Context, *linodego.ListOptions) ([]linodego.Volume, error)


### PR DESCRIPTION
## Summary

Centralizes Linode API list pagination behind a fixed page size of 500 (the API max) and applies it to all controller-side list calls, reducing the number of API round-trips per list operation.

## Changes

- `pkg/linode-client`: adds `DefaultPageSize = 500` and `DefaultListOptions(page, filter)` (page size pinned to the max).
- `controllerserver_helper.go`: list calls now pass `DefaultListOptions` instead of `nil`.
- `controllerserver.go`: `ListVolumes` uses explicit 1-based paging and derives `NextToken` from full-page responses.
- Adds `TestListVolumesPagination`.

## Design decisions

1. **Fixed 500 page size** on all list calls to minimize Linode API requests.
2. **`ListVolumes` ignores `max_entries`** — our only caller doesn't set it, and 500 entries is well under the 4MB gRPC limit, so honoring it adds complexity for no benefit.
3. **`starting_token` is the 1-based page number**; tokens `< 1` are rejected since linodego treats page `0` as "fetch all pages."
4. **Invalid `starting_token` returns `codes.Aborted`**, per the CSI spec.

---

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests?
1. [x] Are you addressing a single feature in this PR?
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language?
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed?
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)
