### PR TITLE
feat: hot-reload apiToken

### DIFF
--- a/deploy/kubernetes/base/ss-csi-linode-controller.yaml
+++ b/deploy/kubernetes/base/ss-csi-linode-controller.yaml
@@ -95,11 +95,18 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            # Default: inject LINODE_TOKEN from the Secret (static for pod lifetime).
             - name: LINODE_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: linode
                   key: token
+            # Opt-in hot-reload: comment out LINODE_TOKEN above and uncomment the
+            # block below (plus the linode-api-token volumeMount/volume). The
+            # controller re-reads the mounted file after a short cache TTL so
+            # token rotation does not require restarting the controller pod.
+            # - name: LINODE_API_TOKEN_FILE
+            #   value: /var/run/secrets/linode/api-token
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -108,6 +115,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            # Opt-in hot-reload (pair with LINODE_API_TOKEN_FILE above):
+            # - name: linode-api-token
+            #   mountPath: /var/run/secrets/linode
+            #   readOnly: true
       tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -118,3 +129,10 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+        # Opt-in hot-reload (pair with LINODE_API_TOKEN_FILE / volumeMount above):
+        # - name: linode-api-token
+        #   secret:
+        #     secretName: linode
+        #     items:
+        #       - key: token
+        #         path: api-token

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,6 +74,36 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 - Modify variables using the `--set var=value` flag or by providing a custom `values.yaml` with `-f custom-values.yaml`.
 - For a comprehensive list of configurable variables, refer to [`helm-chart/csi-driver/values.yaml`](https://github.com/linode/linode-blockstorage-csi-driver/blob/main/helm-chart/csi-driver/values.yaml).
 
+###### Hot-reload Linode API token (optional)
+
+By default the controller receives `LINODE_TOKEN` from a Kubernetes Secret via env injection. Environment variables are fixed for the lifetime of the pod, so rotating the PAT normally requires restarting the CSI controller.
+
+To rotate the token **without restarting** the controller, mount the Secret as a file instead. The controller re-reads the file periodically (default cache TTL: 1 minute; override with `LINODE_API_TOKEN_CACHE_TTL_SECONDS`).
+
+```yaml
+# values.yaml — enable file-mount mode (defaults for name/keys/path live in chart values.yaml)
+secretRef:
+  mountSecret: true
+  # optional overrides:
+  # name: linode
+  # apiTokenRef: token
+  # mountPath: /var/run/secrets/linode/api-token
+```
+
+Helm example:
+
+```sh
+helm upgrade --install linode-csi-driver \
+  --set secretRef.name=linode \
+  --set secretRef.apiTokenRef=token \
+  --set secretRef.mountSecret=true \
+  linode-csi/linode-blockstorage-csi-driver
+```
+
+After enabling mount mode, update the Secret data and wait past the cache TTL; the controller will pick up the new token on subsequent Linode API calls. The node DaemonSet is unchanged and does not mount the API token.
+
+For kubectl/kustomize installs, see the commented `LINODE_API_TOKEN_FILE` / `linode-api-token` volume blocks in `deploy/kubernetes/base/ss-csi-linode-controller.yaml`.
+
 ###### Controller kubeconfig (optional)
 
 If your environment requires the controller to use a kubeconfig file explicitly, enable the controller kubeconfig by providing the following values. The Secret will be mounted as a directory and the sidecars will read the file `<mountDir>/<secretKey>`.

--- a/helm-chart/csi-driver/templates/csi-linode-controller.yaml
+++ b/helm-chart/csi-driver/templates/csi-linode-controller.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.controller.enabled }}
+{{- $secretName := .Values.secretRef.name }}
+{{- $apiTokenKey := .Values.secretRef.apiTokenRef }}
+{{- $mountSecret := .Values.secretRef.mountSecret }}
+{{- $tokenFilePath := .Values.secretRef.mountPath }}
+{{- $tokenFileDir := dir $tokenFilePath }}
+{{- $tokenFileName := base $tokenFilePath }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -166,11 +172,16 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- if $mountSecret }}
+            - name: LINODE_API_TOKEN_FILE
+              value: {{ $tokenFilePath | quote }}
+            {{- else }}
             - name: LINODE_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.secretRef }}{{ .Values.secretRef.name | default "linode" }}{{ else }}"linode"{{ end }}
-                  key: {{ if .Values.secretRef }}{{ .Values.secretRef.apiTokenRef | default "token" }}{{ else }}"token"{{ end }}
+                  name: {{ $secretName | quote }}
+                  key: {{ $apiTokenKey | quote }}
+            {{- end }}
             - name: ENABLE_METRICS
               value: {{ .Values.enableMetrics | quote}}
             - name: METRICS_PORT
@@ -193,6 +204,11 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+            {{- if $mountSecret }}
+            - mountPath: {{ $tokenFileDir | quote }}
+              name: linode-api-token
+              readOnly: true
+            {{- end }}
             {{- with .Values.csiLinodePlugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -226,6 +242,14 @@ spec:
             path: /dev
             type: Directory
           name: dev
+        {{- if $mountSecret }}
+        - name: linode-api-token
+          secret:
+            secretName: {{ $secretName | quote }}
+            items:
+              - key: {{ $apiTokenKey | quote }}
+                path: {{ $tokenFileName | quote }}
+        {{- end }}
         {{- with .Values.controller.kubeconfig }}
           {{- if and .secretName .secretKey }}
         - name: controller-kubeconfig

--- a/helm-chart/csi-driver/templates/csi-secrets.yaml
+++ b/helm-chart/csi-driver/templates/csi-secrets.yaml
@@ -1,12 +1,16 @@
-{{- if not .Values.secretRef }}
+{{/*
+Create a Secret when apiToken is provided. Leave apiToken empty and set
+secretRef.name to use an externally managed Secret instead.
+*/}}
+{{- if .Values.apiToken }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: linode
+  name: {{ .Values.secretRef.name | quote }}
   namespace: {{ required ".Values.namespace required" .Values.namespace }}
 stringData:
-  token: {{ required ".Values.apiToken required" .Values.apiToken }}
-  region: {{ required ".Values.region required" .Values.region }}
+  {{ .Values.secretRef.apiTokenRef }}: {{ required ".Values.apiToken required" .Values.apiToken | quote }}
+  {{ .Values.secretRef.regionRef }}: {{ required ".Values.region required" .Values.region | quote }}
 type: Opaque
 {{- end }}
 

--- a/helm-chart/csi-driver/templates/csi-secrets.yaml
+++ b/helm-chart/csi-driver/templates/csi-secrets.yaml
@@ -7,10 +7,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.secretRef.name | quote }}
-  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+  namespace: {{ required ".Values.namespace required" .Values.namespace | quote }}
 stringData:
-  {{ .Values.secretRef.apiTokenRef }}: {{ required ".Values.apiToken required" .Values.apiToken | quote }}
-  {{ .Values.secretRef.regionRef }}: {{ required ".Values.region required" .Values.region | quote }}
+  {{ .Values.secretRef.apiTokenRef | quote }}: {{ required ".Values.apiToken required" .Values.apiToken | quote }}
+  {{ .Values.secretRef.regionRef | quote }}: {{ required ".Values.region required" .Values.region | quote }}
 type: Opaque
 {{- end }}
 

--- a/helm-chart/csi-driver/values.yaml
+++ b/helm-chart/csi-driver/values.yaml
@@ -1,8 +1,9 @@
 # Secrets:
-# apiToken [Required if secretRef is not set] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens)
+# apiToken [Required unless using an externally managed Secret] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens)
+# When set, the chart creates a Secret named secretRef.name. Leave empty if the Secret already exists.
 apiToken: ""
 
-# region [Required if secretRef is not set] - Must be a Linode region. (https://api.linode.com/v4/regions)
+# region [Required when apiToken is set] - Must be a Linode region. (https://api.linode.com/v4/regions)
 region: ""
 
 # enableMetrics: This variable must be set to true to get metrics
@@ -26,11 +27,20 @@ namespace: kube-system
 # Add a kubelet path variable to be used across containers for alternate k8s distros (e.g K0s, K3s)
 kubeletPath: "/var/lib/kubelet"
 
-# Set these values if your APIToken and region are already present in a k8s secret.
-# secretRef:
-#   name: "linode"
-#   apiTokenRef: "apiToken"
-#   regionRef: "region"
+# Secret used by the controller for the Linode API token (and by the chart-created
+# Secret when apiToken/region are set). Override name/keys when using an existing Secret.
+# Leave apiToken empty and point name at your Secret to use an externally managed one.
+secretRef:
+  name: "linode"
+  apiTokenRef: "token"
+  regionRef: "region"
+  # Enable mounted token file mode on the controller only. Default false keeps
+  # legacy LINODE_TOKEN env injection via secretKeyRef.
+  # When true, the Secret is mounted and the controller re-reads the token
+  # (with a short cache) so you can rotate the PAT without restarting CSI controller pods.
+  mountSecret: false
+  # Token file path used when mountSecret=true.
+  mountPath: /var/run/secrets/linode/api-token
 
 # Default storageClass is "linode-block-storage-retain" but it can be set to
 # "linode-block-storage" or left as an empty string

--- a/main.go
+++ b/main.go
@@ -130,16 +130,23 @@ func handle(ctx context.Context) error {
 	log.V(4).Info("Driver vendor version", "version", vendorVersion)
 
 	cfg := loadConfig()
+	// staticToken covers --LINODE_TOKEN and LINODE_TOKEN via envflag; file mount
+	// is preferred when present so tokens can rotate without restart.
+	tokenProvider, tokenSource, tokenErr := linodeclient.TokenProviderFromFileOrEnv(ctx, cfg.linodeToken)
 	if cfg.driverRole == "controller" {
-		if cfg.linodeToken == "" {
-			return errors.New("linode token required")
+		if tokenErr != nil {
+			return fmt.Errorf("linode token required: %w", tokenErr)
 		}
+		log.V(2).Info("Using Linode API token", "source", tokenSource)
+	} else if tokenErr != nil {
+		// Node plugin typically does not need a Linode API token.
+		tokenProvider = func(context.Context) (string, error) { return "", nil }
 	}
 	linodeDriver := driver.GetLinodeDriver(ctx)
 
 	// Initialize Linode Driver (Move setup to main?)
 	uaPrefix := fmt.Sprintf("LinodeCSI/%s", vendorVersion)
-	cloudProvider, err := linodeclient.NewLinodeClient(cfg.linodeToken, uaPrefix, cfg.linodeURL)
+	cloudProvider, err := linodeclient.NewLinodeClientWithTokenProvider(uaPrefix, cfg.linodeURL, tokenProvider)
 	if err != nil {
 		return fmt.Errorf("failed to set up linode client: %w", err)
 	}

--- a/pkg/linode-client/linode_client.go
+++ b/pkg/linode-client/linode_client.go
@@ -2,6 +2,8 @@ package linodeclient
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/linode/linodego/v2"
 )
@@ -34,17 +36,60 @@ type LinodeClient interface {
 // linodego.Client implements LinodeClient
 var _ LinodeClient = (*linodego.Client)(nil)
 
+type tokenTransport struct {
+	base          http.RoundTripper
+	tokenProvider TokenProvider
+}
+
+func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.tokenProvider(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	clone := req.Clone(req.Context())
+	// Node plugin may intentionally supply an empty token (no Linode API calls).
+	// Omit Authorization rather than sending "Bearer " with no credentials.
+	if token != "" {
+		clone.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(clone)
+}
+
+// NewLinodeClient creates a Linode API client authenticated with a static token.
+// Prefer NewLinodeClientWithTokenProvider when tokens may rotate without restart.
 func NewLinodeClient(token, ua, apiURL string) (*linodego.Client, error) {
+	return NewLinodeClientWithTokenProvider(ua, apiURL, StaticTokenProvider(token))
+}
+
+// NewLinodeClientWithTokenProvider creates a Linode API client that obtains the
+// Authorization bearer token from tokenProvider on each HTTP request.
+func NewLinodeClientWithTokenProvider(ua, apiURL string, tokenProvider TokenProvider) (*linodego.Client, error) {
+	if tokenProvider == nil {
+		return nil, fmt.Errorf("token provider is required")
+	}
+
+	httpClient := &http.Client{
+		Transport: &tokenTransport{
+			base:          http.DefaultTransport,
+			tokenProvider: tokenProvider,
+		},
+	}
+
 	// Use linodego built-in http client which supports setting root CA cert
-	linodeClient, err := linodego.NewClient(nil)
+	// when no custom transport is set; with a custom transport we inject the token.
+	linodeClient, err := linodego.NewClient(httpClient)
 	if err != nil {
 		return nil, err
 	}
 	// Only override the base URL if a custom API URL is provided. Recent versions
 	// of linodego return an error when given an empty string to UseURL.
-	var (
-		client *linodego.Client
-	)
+	var client *linodego.Client
 	if apiURL != "" {
 		client, err = linodeClient.UseURL(apiURL)
 		if err != nil {
@@ -54,7 +99,8 @@ func NewLinodeClient(token, ua, apiURL string) (*linodego.Client, error) {
 		client = &linodeClient
 	}
 	client.SetUserAgent(ua)
-	client.SetToken(token)
+	// Do not call SetToken: auth is applied per-request by tokenTransport so
+	// file-backed tokens can rotate without reconstructing the client.
 
 	return client, nil
 }

--- a/pkg/linode-client/linode_client_test.go
+++ b/pkg/linode-client/linode_client_test.go
@@ -1,9 +1,14 @@
 package linodeclient
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
-
-	"github.com/linode/linodego/v2"
 )
 
 func TestNewLinodeClient(t *testing.T) {
@@ -15,7 +20,6 @@ func TestNewLinodeClient(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *linodego.Client
 		wantErr bool
 	}{
 		{
@@ -25,7 +29,6 @@ func TestNewLinodeClient(t *testing.T) {
 				ua:     "test-user-agent",
 				apiURL: "",
 			},
-			want:    &linodego.Client{},
 			wantErr: false,
 		},
 		{
@@ -35,7 +38,6 @@ func TestNewLinodeClient(t *testing.T) {
 				ua:     "test-user-agent",
 				apiURL: "https://api.linode.com/v4",
 			},
-			want:    &linodego.Client{},
 			wantErr: false,
 		},
 		{
@@ -45,7 +47,6 @@ func TestNewLinodeClient(t *testing.T) {
 				ua:     "test-user-agent",
 				apiURL: "://invalid-url",
 			},
-			want:    nil,
 			wantErr: true,
 		},
 	}
@@ -61,8 +62,123 @@ func TestNewLinodeClient(t *testing.T) {
 			}
 			if got == nil {
 				t.Errorf("NewLinodeClient() returned nil, expected non-nil")
-				return
 			}
 		})
+	}
+}
+
+func TestNewLinodeClientWithTokenProviderNil(t *testing.T) {
+	_, err := NewLinodeClientWithTokenProvider("ua", "", nil)
+	if err == nil {
+		t.Fatal("expected error for nil token provider")
+	}
+}
+
+// TestTokenTransportAuthorization builds the real shipped client with a
+// TokenProvider, issues requests through linodego against a local server, and
+// asserts Authorization is set per-request from the provider (including after
+// the provider returns a different token).
+func TestTokenTransportAuthorization(t *testing.T) {
+	var gotAuth []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[],"page":1,"pages":1,"results":0}`)
+	}))
+	t.Cleanup(server.Close)
+
+	var token atomic.Value
+	token.Store("token-one")
+	provider := TokenProvider(func(context.Context) (string, error) {
+		v := token.Load()
+		s, ok := v.(string)
+		if !ok {
+			return "", fmt.Errorf("unexpected token type %T", v)
+		}
+		return s, nil
+	})
+
+	client, err := NewLinodeClientWithTokenProvider("test-ua", server.URL+"/v4", provider)
+	if err != nil {
+		t.Fatalf("NewLinodeClientWithTokenProvider: %v", err)
+	}
+	// linodego uses `for range retryCount` attempts; keep a small positive count.
+	client.SetRetryCount(1)
+
+	if _, err := client.ListVolumes(t.Context(), nil); err != nil {
+		t.Fatalf("ListVolumes with token-one: %v", err)
+	}
+
+	token.Store("token-two")
+	if _, err := client.ListVolumes(t.Context(), nil); err != nil {
+		t.Fatalf("ListVolumes with token-two: %v", err)
+	}
+
+	if len(gotAuth) < 2 {
+		t.Fatalf("expected at least 2 requests with Authorization, got %v", gotAuth)
+	}
+	if gotAuth[0] != "Bearer token-one" {
+		t.Fatalf("first Authorization = %q, want %q", gotAuth[0], "Bearer token-one")
+	}
+	last := gotAuth[len(gotAuth)-1]
+	if last != "Bearer token-two" {
+		t.Fatalf("last Authorization = %q, want %q", last, "Bearer token-two")
+	}
+}
+
+func TestTokenTransportUsesProviderError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be reached when token provider fails")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	provider := TokenProvider(func(context.Context) (string, error) {
+		return "", errors.New("token missing")
+	})
+	client, err := NewLinodeClientWithTokenProvider("test-ua", server.URL+"/v4", provider)
+	if err != nil {
+		t.Fatalf("NewLinodeClientWithTokenProvider: %v", err)
+	}
+	client.SetRetryCount(1)
+
+	_, err = client.ListVolumes(t.Context(), nil)
+	if err == nil {
+		t.Fatal("expected error when token provider fails")
+	}
+}
+
+func TestTokenTransportOmitsEmptyAuthorization(t *testing.T) {
+	var gotAuth []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Header.Get returns "" when unset; distinguish from "Bearer ".
+		if _, ok := r.Header["Authorization"]; ok {
+			gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		} else {
+			gotAuth = append(gotAuth, "<missing>")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[],"page":1,"pages":1,"results":0}`)
+	}))
+	t.Cleanup(server.Close)
+
+	provider := TokenProvider(func(context.Context) (string, error) {
+		return "", nil
+	})
+	client, err := NewLinodeClientWithTokenProvider("test-ua", server.URL+"/v4", provider)
+	if err != nil {
+		t.Fatalf("NewLinodeClientWithTokenProvider: %v", err)
+	}
+	client.SetRetryCount(1)
+
+	// Call may fail auth-wise on a real API; against our stub it should succeed.
+	if _, err := client.ListVolumes(t.Context(), nil); err != nil {
+		t.Fatalf("ListVolumes with empty token: %v", err)
+	}
+	if len(gotAuth) == 0 {
+		t.Fatal("expected at least one request")
+	}
+	if gotAuth[0] != "<missing>" {
+		t.Fatalf("Authorization = %q, want header omitted", gotAuth[0])
 	}
 }

--- a/pkg/linode-client/token.go
+++ b/pkg/linode-client/token.go
@@ -1,0 +1,148 @@
+package linodeclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// AccessTokenEnv is the environment variable holding a static Linode API token.
+	AccessTokenEnv = "LINODE_TOKEN"
+	// TokenFilePathEnv is the environment variable pointing at a mounted token file.
+	TokenFilePathEnv = "LINODE_API_TOKEN_FILE"
+	// TokenCacheTTLEnv optionally overrides the token file cache TTL in seconds.
+	TokenCacheTTLEnv = "LINODE_API_TOKEN_CACHE_TTL_SECONDS"
+	// DefaultTokenFilePath is the default path for a secret-mounted API token.
+	DefaultTokenFilePath = "/var/run/secrets/linode/api-token"
+	// DefaultTokenFileCacheTTL is how long a file-backed token is cached.
+	DefaultTokenFileCacheTTL = time.Minute
+)
+
+// TokenProvider returns a Linode API token for the current request.
+// Implementations may re-read a mounted secret so tokens can rotate without a restart.
+type TokenProvider func(context.Context) (string, error)
+
+// StaticTokenProvider returns a TokenProvider that always yields the given token.
+func StaticTokenProvider(token string) TokenProvider {
+	return staticTokenProvider{token: token}.GetToken
+}
+
+type staticTokenProvider struct {
+	token string
+}
+
+func (t staticTokenProvider) GetToken(context.Context) (string, error) {
+	if t.token == "" {
+		return "", fmt.Errorf("%s must be set in the environment (use a k8s secret)", AccessTokenEnv)
+	}
+	return t.token, nil
+}
+
+// TokenFileProvider reads a token from a file with a short TTL cache so secret
+// updates are picked up without restarting the process.
+type TokenFileProvider struct {
+	path     string
+	now      func() time.Time
+	cacheTTL time.Duration
+
+	mu          sync.RWMutex
+	cachedToken string
+	expiresAt   time.Time
+}
+
+// NewTokenFileProvider constructs a file-backed token provider.
+func NewTokenFileProvider(path string, cacheTTL time.Duration) *TokenFileProvider {
+	return &TokenFileProvider{
+		path:     path,
+		cacheTTL: cacheTTL,
+	}
+}
+
+func (t *TokenFileProvider) String() string {
+	return t.path
+}
+
+func (t *TokenFileProvider) nowTime() time.Time {
+	if t.now != nil {
+		return t.now()
+	}
+	return time.Now()
+}
+
+// GetToken returns a cached token when still valid, otherwise re-reads the file.
+func (t *TokenFileProvider) GetToken(_ context.Context) (string, error) {
+	now := t.nowTime()
+	cacheTTL := t.cacheTTL
+	if cacheTTL <= 0 {
+		cacheTTL = DefaultTokenFileCacheTTL
+	}
+
+	t.mu.RLock()
+	if t.cachedToken != "" && now.Before(t.expiresAt) {
+		token := t.cachedToken
+		t.mu.RUnlock()
+		return token, nil
+	}
+	t.mu.RUnlock()
+
+	rawToken, err := os.ReadFile(t.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read token file %q: %w", t.String(), err)
+	}
+
+	token := strings.TrimSpace(string(rawToken))
+	if token == "" {
+		return "", fmt.Errorf("token file %q is empty", t.String())
+	}
+
+	t.mu.Lock()
+	t.cachedToken = token
+	t.expiresAt = t.nowTime().Add(cacheTTL)
+	t.mu.Unlock()
+
+	return token, nil
+}
+
+// TokenFileCacheTTLFromEnv returns the configured cache TTL or the default.
+func TokenFileCacheTTLFromEnv() time.Duration {
+	tokenCacheTTL := DefaultTokenFileCacheTTL
+	if raw, ok := os.LookupEnv(TokenCacheTTLEnv); ok {
+		if ttlSeconds, err := strconv.Atoi(raw); err == nil && ttlSeconds > 0 {
+			tokenCacheTTL = time.Duration(ttlSeconds) * time.Second
+		}
+	}
+	return tokenCacheTTL
+}
+
+// TokenProviderFromFileOrEnv prefers a mounted token file (when readable), then
+// falls back to staticToken (e.g. from --LINODE_TOKEN / envflag), then to the
+// LINODE_TOKEN environment variable. Returns an error when no source yields a token.
+// The second return value describes the chosen source for logging.
+func TokenProviderFromFileOrEnv(ctx context.Context, staticToken string) (TokenProvider, string, error) {
+	tokenFilePath := strings.TrimSpace(os.Getenv(TokenFilePathEnv))
+	if tokenFilePath == "" {
+		tokenFilePath = DefaultTokenFilePath
+	}
+
+	fileProvider := NewTokenFileProvider(tokenFilePath, TokenFileCacheTTLFromEnv())
+	_, fileErr := fileProvider.GetToken(ctx)
+	if fileErr == nil {
+		return fileProvider.GetToken, fmt.Sprintf("file %q", fileProvider.String()), nil
+	}
+
+	if token := strings.TrimSpace(staticToken); token != "" {
+		return StaticTokenProvider(token), fmt.Sprintf("flag or environment variable %q", AccessTokenEnv), nil
+	}
+
+	if envToken := strings.TrimSpace(os.Getenv(AccessTokenEnv)); envToken != "" {
+		return StaticTokenProvider(envToken), fmt.Sprintf("environment variable %q", AccessTokenEnv), nil
+	}
+
+	return nil, "", fmt.Errorf("failed to load linode api token from %s=%q: %w; fallback %s is not set",
+		TokenFilePathEnv, tokenFilePath, fileErr, AccessTokenEnv)
+}

--- a/pkg/linode-client/token.go
+++ b/pkg/linode-client/token.go
@@ -38,7 +38,7 @@ type staticTokenProvider struct {
 
 func (t staticTokenProvider) GetToken(context.Context) (string, error) {
 	if t.token == "" {
-		return "", fmt.Errorf("%s must be set in the environment (use a k8s secret)", AccessTokenEnv)
+		return "", fmt.Errorf("linode API token is empty; set %s (flag, env, or k8s secret)", AccessTokenEnv)
 	}
 	return t.token, nil
 }

--- a/pkg/linode-client/token_test.go
+++ b/pkg/linode-client/token_test.go
@@ -1,0 +1,190 @@
+package linodeclient
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeTokenFile(t *testing.T, dir, token string) string {
+	t.Helper()
+	path := filepath.Join(dir, "api-token")
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	return path
+}
+
+func TestTokenFileProviderCache(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTokenFile(t, dir, "token-v1")
+
+	now := time.Now()
+	provider := NewTokenFileProvider(path, DefaultTokenFileCacheTTL)
+	provider.now = func() time.Time { return now }
+
+	first, err := provider.GetToken(t.Context())
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if first != "token-v1" {
+		t.Fatalf("first token = %q, want token-v1", first)
+	}
+
+	if err := os.WriteFile(path, []byte("token-v2"), 0o600); err != nil {
+		t.Fatalf("update token file: %v", err)
+	}
+
+	cached, err := provider.GetToken(t.Context())
+	if err != nil {
+		t.Fatalf("GetToken cached: %v", err)
+	}
+	if cached != "token-v1" {
+		t.Fatalf("cached token = %q, want token-v1 (within TTL)", cached)
+	}
+
+	now = now.Add(DefaultTokenFileCacheTTL + time.Second)
+	refreshed, err := provider.GetToken(t.Context())
+	if err != nil {
+		t.Fatalf("GetToken after TTL: %v", err)
+	}
+	if refreshed != "token-v2" {
+		t.Fatalf("refreshed token = %q, want token-v2", refreshed)
+	}
+}
+
+func TestTokenFileProviderEmptyFile(t *testing.T) {
+	path := writeTokenFile(t, t.TempDir(), "   \n")
+	provider := NewTokenFileProvider(path, DefaultTokenFileCacheTTL)
+	_, err := provider.GetToken(t.Context())
+	if err == nil {
+		t.Fatal("expected error for empty token file")
+	}
+}
+
+func TestTokenFileProviderMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-token")
+	provider := NewTokenFileProvider(path, DefaultTokenFileCacheTTL)
+	_, err := provider.GetToken(t.Context())
+	if err == nil {
+		t.Fatal("expected error for missing token file")
+	}
+}
+
+func TestTokenFileCacheTTLFromEnv(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(TokenCacheTTLEnv, "")
+		if got := TokenFileCacheTTLFromEnv(); got != DefaultTokenFileCacheTTL {
+			t.Fatalf("got %v, want default %v", got, DefaultTokenFileCacheTTL)
+		}
+	})
+	t.Run("configured", func(t *testing.T) {
+		t.Setenv(TokenCacheTTLEnv, "7")
+		if got := TokenFileCacheTTLFromEnv(); got != 7*time.Second {
+			t.Fatalf("got %v, want 7s", got)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		t.Setenv(TokenCacheTTLEnv, "invalid")
+		if got := TokenFileCacheTTLFromEnv(); got != DefaultTokenFileCacheTTL {
+			t.Fatalf("got %v, want default", got)
+		}
+	})
+	t.Run("non-positive", func(t *testing.T) {
+		t.Setenv(TokenCacheTTLEnv, "0")
+		if got := TokenFileCacheTTLFromEnv(); got != DefaultTokenFileCacheTTL {
+			t.Fatalf("got %v, want default", got)
+		}
+	})
+}
+
+func TestTokenProviderFromFileOrEnv(t *testing.T) {
+	t.Run("uses file when available", func(t *testing.T) {
+		t.Setenv(AccessTokenEnv, "env-token")
+		path := writeTokenFile(t, t.TempDir(), "file-token")
+		t.Setenv(TokenFilePathEnv, path)
+
+		provider, source, err := TokenProviderFromFileOrEnv(t.Context(), "static-token")
+		if err != nil {
+			t.Fatalf("TokenProviderFromFileOrEnv: %v", err)
+		}
+		wantSource := `file "` + path + `"`
+		if source != wantSource {
+			t.Fatalf("source = %q, want %q", source, wantSource)
+		}
+		token, err := provider(t.Context())
+		if err != nil {
+			t.Fatalf("provider: %v", err)
+		}
+		if token != "file-token" {
+			t.Fatalf("token = %q, want file-token", token)
+		}
+	})
+
+	t.Run("falls back to static token when file missing", func(t *testing.T) {
+		t.Setenv(AccessTokenEnv, "")
+		t.Setenv(TokenFilePathEnv, filepath.Join(t.TempDir(), "missing-token-file"))
+
+		provider, source, err := TokenProviderFromFileOrEnv(t.Context(), "static-token")
+		if err != nil {
+			t.Fatalf("TokenProviderFromFileOrEnv: %v", err)
+		}
+		wantSource := `flag or environment variable "LINODE_TOKEN"`
+		if source != wantSource {
+			t.Fatalf("source = %q, want %q", source, wantSource)
+		}
+		token, err := provider(t.Context())
+		if err != nil {
+			t.Fatalf("provider: %v", err)
+		}
+		if token != "static-token" {
+			t.Fatalf("token = %q, want static-token", token)
+		}
+	})
+
+	t.Run("falls back to env when file and static missing", func(t *testing.T) {
+		t.Setenv(AccessTokenEnv, "env-token")
+		t.Setenv(TokenFilePathEnv, filepath.Join(t.TempDir(), "missing-token-file"))
+
+		provider, source, err := TokenProviderFromFileOrEnv(t.Context(), "")
+		if err != nil {
+			t.Fatalf("TokenProviderFromFileOrEnv: %v", err)
+		}
+		wantSource := `environment variable "LINODE_TOKEN"`
+		if source != wantSource {
+			t.Fatalf("source = %q, want %q", source, wantSource)
+		}
+		token, err := provider(t.Context())
+		if err != nil {
+			t.Fatalf("provider: %v", err)
+		}
+		if token != "env-token" {
+			t.Fatalf("token = %q, want env-token", token)
+		}
+	})
+
+	t.Run("errors when all unavailable", func(t *testing.T) {
+		t.Setenv(AccessTokenEnv, "")
+		t.Setenv(TokenFilePathEnv, filepath.Join(t.TempDir(), "missing-token-file"))
+
+		_, _, err := TokenProviderFromFileOrEnv(t.Context(), "")
+		if err == nil {
+			t.Fatal("expected error when file, static, and env unavailable")
+		}
+	})
+}
+
+func TestStaticTokenProvider(t *testing.T) {
+	token, err := StaticTokenProvider("static")(t.Context())
+	if err != nil {
+		t.Fatalf("StaticTokenProvider: %v", err)
+	}
+	if token != "static" {
+		t.Fatalf("token = %q, want static", token)
+	}
+	_, err = StaticTokenProvider("")(t.Context())
+	if err == nil {
+		t.Fatal("expected error for empty static token")
+	}
+}


### PR DESCRIPTION
Inspired by [linode/linode-cloud-controller-manager#576](https://github.com/linode/linode-cloud-controller-manager/pull/576), adds the ability to store `apiToken` for hot-reloading the token when rotated.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

```bash
➜  linode-blockstorage-csi-driver git:(feat/hot-reload-token) export DOCKERFILE=Dockerfile.dev IMAGE_VERSION=hot-reload-token
➜  linode-blockstorage-csi-driver git:(feat/hot-reload-token) make docker-build test
DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 --progress=plain \
		-t index.docker.io/linode/linode-blockstorage-csi-driver:hot-reload-token \
		--build-arg REV=hot-reload-token \
		--build-arg GOLANGCI_LINT_VERSION=v2.12.2 \
		-f ./Dockerfile.dev .
#0 building with "desktop-linux" instance using docker driver
#.....
docker run --rm --platform=linux/amd64 --privileged -it index.docker.io/linode/linode-blockstorage-csi-driver:hot-reload-token go test `go list ./... | grep -v ./mocks$` -cover
go: downloading github.com/golang/mock v1.6.0
go: downloading github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
	github.com/linode/linode-blockstorage-csi-driver		coverage: 0.0% of statements
ok  	github.com/linode/linode-blockstorage-csi-driver/internal/driver	0.223s	coverage: 82.2% of statements
	github.com/linode/linode-blockstorage-csi-driver/pkg/cryptsetup-client		coverage: 0.0% of statements
ok  	github.com/linode/linode-blockstorage-csi-driver/pkg/device-manager	0.090s	coverage: 100.0% of statements
	github.com/linode/linode-blockstorage-csi-driver/pkg/filesystem		coverage: 0.0% of statements
	github.com/linode/linode-blockstorage-csi-driver/pkg/hwinfo		coverage: 0.0% of statements
ok  	github.com/linode/linode-blockstorage-csi-driver/pkg/linode-client	0.119s	coverage: 94.2% of statements
ok  	github.com/linode/linode-blockstorage-csi-driver/pkg/linode-volumes	0.105s	coverage: 100.0% of statements
ok  	github.com/linode/linode-blockstorage-csi-driver/pkg/logger	0.079s	coverage: 94.4% of statements
ok  	github.com/linode/linode-blockstorage-csi-driver/pkg/mount-manager	0.106s	coverage: 100.0% of statements
	github.com/linode/linode-blockstorage-csi-driver/pkg/observability		coverage: 0.0% of statements
```
```bash
➜  linode-blockstorage-csi-driver git:(feat/hot-reload-token) go test -v ./pkg/linode-client/...
=== RUN   TestNewLinodeClient
=== RUN   TestNewLinodeClient/Valid_input_without_custom_API_URL
=== RUN   TestNewLinodeClient/Valid_input_with_custom_API_URL
=== RUN   TestNewLinodeClient/Invalid_API_URL
--- PASS: TestNewLinodeClient (0.00s)
    --- PASS: TestNewLinodeClient/Valid_input_without_custom_API_URL (0.00s)
    --- PASS: TestNewLinodeClient/Valid_input_with_custom_API_URL (0.00s)
    --- PASS: TestNewLinodeClient/Invalid_API_URL (0.00s)
=== RUN   TestNewLinodeClientWithTokenProviderNil
--- PASS: TestNewLinodeClientWithTokenProviderNil (0.00s)
=== RUN   TestTokenTransportAuthorization
--- PASS: TestTokenTransportAuthorization (0.00s)
=== RUN   TestTokenTransportUsesProviderError
--- PASS: TestTokenTransportUsesProviderError (0.00s)
=== RUN   TestTokenFileProviderCache
--- PASS: TestTokenFileProviderCache (0.00s)
=== RUN   TestTokenFileProviderEmptyFile
--- PASS: TestTokenFileProviderEmptyFile (0.00s)
=== RUN   TestTokenFileProviderMissingFile
--- PASS: TestTokenFileProviderMissingFile (0.00s)
=== RUN   TestTokenFileCacheTTLFromEnv
=== RUN   TestTokenFileCacheTTLFromEnv/default
=== RUN   TestTokenFileCacheTTLFromEnv/configured
=== RUN   TestTokenFileCacheTTLFromEnv/invalid
=== RUN   TestTokenFileCacheTTLFromEnv/non-positive
--- PASS: TestTokenFileCacheTTLFromEnv (0.00s)
    --- PASS: TestTokenFileCacheTTLFromEnv/default (0.00s)
    --- PASS: TestTokenFileCacheTTLFromEnv/configured (0.00s)
    --- PASS: TestTokenFileCacheTTLFromEnv/invalid (0.00s)
    --- PASS: TestTokenFileCacheTTLFromEnv/non-positive (0.00s)
=== RUN   TestTokenProviderFromFileOrEnv
=== RUN   TestTokenProviderFromFileOrEnv/uses_file_when_available
=== RUN   TestTokenProviderFromFileOrEnv/falls_back_to_env_when_file_missing
=== RUN   TestTokenProviderFromFileOrEnv/errors_when_both_unavailable
--- PASS: TestTokenProviderFromFileOrEnv (0.00s)
    --- PASS: TestTokenProviderFromFileOrEnv/uses_file_when_available (0.00s)
    --- PASS: TestTokenProviderFromFileOrEnv/falls_back_to_env_when_file_missing (0.00s)
    --- PASS: TestTokenProviderFromFileOrEnv/errors_when_both_unavailable (0.00s)
=== RUN   TestStaticTokenProvider
--- PASS: TestStaticTokenProvider (0.00s)
PASS
ok  	github.com/linode/linode-blockstorage-csi-driver/pkg/linode-client	(cached)
```

Continuation of #591 - CI doesn't like my fork ☹️ 