### PR TITLE
[CI] group renovate security PRs

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,3 +1,4 @@
-# Any file that is not a doc *.md file
+# Any file that is not a doc *.md file or renovate config
 src:
   - "!**/**.md"
+  - "!renovate.json5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           base: ${{ github.ref }}
           filters: .github/filters.yml
+          predicate-quantifier: 'every'
   ci:
     runs-on: ubuntu-latest
     needs: changes

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,7 +11,8 @@
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
    "vulnerabilityAlerts": {
-    "enabled": true
+    "enabled": true,
+    "groupName": "security updates",
   },
   "osvVulnerabilityAlerts": true,
   "platformAutomerge": true,


### PR DESCRIPTION
Adds the missing groupName like we have in CAPL: https://github.com/linode/cluster-api-provider-linode/blob/main/renovate.json5#L15

This will result in opening all vulnerability updates in one PR like so: https://github.com/linode/cluster-api-provider-linode/pull/1104

